### PR TITLE
docs: rewrite GeneralUpdate.Tools doc — accurate, specific, no Bowl

### DIFF
--- a/website/docs/doc/GeneralUpdate.PacketTool.md
+++ b/website/docs/doc/GeneralUpdate.PacketTool.md
@@ -2,989 +2,356 @@
 sidebar_position: 11
 ---
 
-### 简介
+# GeneralUpdate.Tools
 
-GeneralUpdate.Tools 是一款使用 Avalonia 开发的桌面应用程序，支持 Windows / Linux / Mac 跨平台。该工具为开发者提供了三个核心功能模块，用于管理软件更新和扩展。
+## 这是什么
 
+GeneralUpdate.Tools 是一个基于 Avalonia 12 开发的跨平台桌面工具（Windows / Linux / macOS），用于在软件发布流程中生成和管理补丁包、扩展包、版本清单以及执行本地更新仿真。它不替代你的 CI/CD 系统，而是把“打包、校验、验证”这些重复劳动收敛到一个可视化工具中。
 
-| 仓库地址 |
-| ----------------------------------------------------- |
-|  https://github.com/GeneralLibrary/GeneralUpdate.Tools  |
+仓库地址：[https://github.com/GeneralLibrary/GeneralUpdate.Tools](https://github.com/GeneralLibrary/GeneralUpdate.Tools)
 
-| 功能 | 支持 | 说明 |
-| ------------------------------- | -------------- | ------------------------------------------------------------ |
-| 构建补丁包 | 是 | 比较前后版本，识别更新、新增或删除的文件 |
-| 构建版本配置 | 是 | 轻松生成版本配置文件 |
-| 扩展管理器 | 是 | 打包和管理应用程序扩展 |
-| 模拟更新 | 是 | 在本地完整模拟客户端到服务端的更新流程 |
-| 配置生成器 | 是 | 分析 .csproj 自动生成 manifest.json 和项目结构 |
+## 下载与运行
 
-![](imgs\tool.png)
+### 方式一：从源码运行（推荐开发者）
 
-![](imgs\tool2.png)
+当前工具基于 .NET 10 构建。确保本机安装了 [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)：
 
----
-
-## 功能说明
-
-### 1. 构建补丁包
-
-#### 功能介绍
-
-补丁包构建器用于创建差异更新包，通过对比旧版本和新版本，仅打包发生变化的文件，从而大幅减少更新包体积和下载时间。
-
-
-#### 参数说明
-
-| 名称 | 说明 |
-| ---------------- | ------------------------------------------------------------ |
-| 源路径 | 旧版本文件夹的路径 |
-| 目标路径 | 新版本文件夹的路径 |
-| 补丁路径 | 最终更新补丁包将生成的路径 |
-| 构建 | 递归比较源路径和目标路径文件夹中的所有项目文件（DLL、exe 等），通过二进制差异检查和增量检查分析需要更新的文件列表，然后根据文件夹结构打包更新文件 |
-| 清空 | 清除当前输入的内容 |
-
----
-
-### 2. 构建 OSS 版本配置
-
-#### 功能介绍
-
-OSS 版本配置构建器用于生成 `version.json` 配置文件，该文件包含更新包的元数据信息，告知客户端应用程序如何获取和验证更新包。
-
-
-#### 参数说明
-
-| 名称 | 说明 |
-| ---------------------- | ------------------------------------------------------------ |
-| 发布日期时间 | 更新包的发布时间 |
-| 包名 | 更新包的名称 |
-| 哈希值 | 更新包的哈希值（用于完整性验证） |
-| 版本号 | 更新包的版本号 |
-| 下载地址 | 更新包的下载 |
-| 获取哈希 | 获取更新包哈希值的功能 |
-| 追加 | 将新的更新信息追加到现有版本详情中 |
-| 清空 | 清除所有填写的内容 |
-| 复制 | 将生成的内容复制到剪贴板 |
-| 构建 | 将版本配置文件（.json）生成到本地磁盘 |
-
----
-
-### 3. 扩展管理器
-
-#### 功能介绍
-
-扩展管理器（ExtensionView）是 GeneralUpdate.Tools 的核心功能之一，用于将应用程序扩展打包成可分发的标准格式。该工具自动创建包含所有必要元数据的扩展包，支持平台特定配置、依赖管理和自定义属性，非常适合构建插件系统和扩展市场。
-
-
-#### 核心特性
-
-- **完整的元数据管理 **：支持扩展名称、版本、描述、发布者、许可证等标准字段
-- **平台支持 **：可指定目标平台（Windows / Linux / MacOS）
-- **版本兼容性 **：定义最小和最大主机版本要求
-- **依赖管理 **：声明扩展依赖的其他扩展
-- **自动打包 **：自动压缩扩展目录并生成 manifest.json
-- **自定义属性 **：支持添加额外的键值对元数据
-- **分类标签 **：通过类别标签组织和发现扩展
-
----
-
-## 扩展管理器使用指南
-
-### 基本信息字段
-
-#### 扩展名称
-
-**描述**：扩展的唯一标识符，建议使用小写字母和连字符，不含空格。
-
-
-**示例**：`my-awesome-plugin`、`data-exporter`
-
----
-
-#### 显示名称
-
-**描述**：面向用户的友好显示名称，将显示在扩展列表和详情页面中。
-
-
-**示例**：`My Awesome Plugin`、`Data Exporter Tool`
-
----
-
-#### 版本号
-
-**描述**：扩展的版本号，建议遵循语义化版本规范（SemVer），格式为 `主版本.次版本.修订号.构建号`。
-
-
-**示例**：`1.0.0.0`、`2.1.3.0`
-
----
-
-#### 描述
-
-**描述**：扩展功能的详细说明，告诉用户该扩展的用途和特性。支持多行文本。
-
-
-**示例**：
-```
-此扩展为您的应用程序添加强大的数据导出功能，
-支持多种格式，包括 CSV、Excel 和 JSON。
+```powershell
+git clone https://github.com/GeneralLibrary/GeneralUpdate.Tools.git
+cd GeneralUpdate.Tools\src
+dotnet run --project GeneralUpdate.Tools.csproj
 ```
 
----
+### 方式二：下载预编译版本
 
-#### 发布者
+前往 [GeneralUpdate.Tools Releases](https://github.com/GeneralLibrary/GeneralUpdate.Tools/releases) 下载对应平台的可执行文件，直接运行即可。
 
-**描述**：扩展的发布者名称或组织标识符。
+> Simulation 模块内部会调用 `dotnet publish` 构建测试应用，因此使用仿真功能时必须安装 .NET SDK，仅运行 Patch / Extension / OSS / Config 模块则不需要。
 
+## 六个模块速览
 
-**示例**：`YourCompany`、`john-doe`、`awesome-dev-team`
-
----
-
-#### 许可证
-
-**描述**：扩展使用的开源许可证标识符。
-
-
-**示例**：`MIT`、`Apache-2.0`、`GPL-3.0`、`BSD-3-Clause`
-
----
-
-#### 分类
-
-**描述**：扩展所属的分类标签，多个分类用逗号分隔。用于组织和搜索扩展。
-
-
-**示例**：`Tools, Productivity`、`Data, Export, Utilities`
-
-**常见分类 Common Categories**：
-- `Tools` - 工具类
-- `Productivity` - 效率提升
-- `Data` - 数据处理
-- `UI` - 用户界面
-- `Security` - 安全
-- `Development` - 开发
+| 模块 | 你提供 | 工具产出 | 下游消费者 |
+|------|--------|----------|------------|
+| **Patch** | 旧版本目录 + 新版本目录 | `{name}.zip`（含 `.patch` 文件、新文件、`generalupdate.delete.json`） | Server、OSS/CDN、Core Upgrade 进程 |
+| **Extension** | 扩展源目录 + 元数据 | `{name}_{version}.zip`（含 `manifest.json`） | `GeneralUpdate.Extension` 组件 |
+| **OSS Config** | 包名、版本、下载 URL、本地 ZIP（计算 Hash） | `oss_config.json`（版本数组） | OSS 客户端、对象存储发布流程 |
+| **Config** | Client/Upgrade 的 `.csproj` | `generalupdate.manifest.json` + `sample_output/` 发布目录 | Client/Upgrade 启动引导 |
+| **Simulation** | 旧版本目录 + 补丁 ZIP | 本地更新服务 + `simulation_report.md` | 发布前质量把关 |
+| **Hash** | 本地文件（ZIP） | SHA256 小写十六进制字符串 | 完整性校验、服务端版本记录 |
 
 ---
 
-### 路径配置
+## Patch：生成补丁包
 
-#### 扩展目录
+### 解决什么问题
 
-**描述**：包含扩展所有文件的源目录路径。该目录中的所有文件将被打包到最终的扩展包中。
+当你发布了一个新版本，用户不想下载整个安装包。Patch 模块比较旧版本目录和新版本目录，只输出变更内容：修改过的文件生成二进制差分 `.patch`，新增文件直接复制，删除的文件写入清单。差分包通常远小于完整发布目录。
 
+### 输入
 
-**操作 Operation**：点击 "Pick" 按钮选择文件夹
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| Old Directory | ✅ | 用户当前安装的旧版本发布目录，例如 `publish\v1.0.0` |
+| New Directory | ✅ | 准备发布的新版本目录，例如 `publish\v2.0.0` |
+| Package Name | ❌ | 输出 ZIP 文件名（不含 `.zip`），为空时自动生成 `patch_yyyyMMddHHmmss` |
+| Version | ✅ | 目标版本号，格式 `MAJOR.MINOR.PATCH`（如 `2.0.0`）或 `MAJOR.MINOR.PATCH-prerelease+build` |
+| Output Directory | ❌ | ZIP 输出目录，为空时输出到桌面 |
 
-**目录结构示例 Directory Structure**：
+### 工具内部做了什么
+
+1. 校验 old/new 目录存在、version 格式合法。
+2. 创建临时目录 `gupatch_yyyyMMddHHmmss`。
+3. 递归比较 old/new：**修改文件** → 生成 `.patch` 二进制差分；**新增文件** → 直接复制；**删除文件** → 记录 hash 到 `generalupdate.delete.json`。
+4. 将临时目录压缩为 `{PackageName}.zip`。
+5. 删除临时目录，ZIP 保留在 Output Directory。
+
+底层调用的是 `GeneralUpdate.Core.Pipeline.DiffPipeline.CleanAsync(oldDir, newDir, patchDir)`，和你的 CI 脚本走的是同一条代码路径。
+
+### 输出
+
 ```
-MyExtension/
-  ├── bin/
-  │   ├── MyExtension.dll
-  │   └── dependencies/
-  ├── resources/
-  │   ├── icons/
-  │   └── templates/
-  └── README.md
+{OutputDirectory}/{PackageName}.zip
+  ├── changed.dll.patch           ← 二进制差分
+  ├── new_file.dll                ← 新增文件（保持目录结构）
+  └── generalupdate.delete.json    ← 删除清单
 ```
 
----
+### 下游如何使用
 
-#### 导出路径
-
-**描述**：最终生成的扩展包（.zip 文件）的保存目录。
-
-
-**操作 Operation**：点击 "Pick" 按钮选择保存位置
-
-**输出格式 Output Format**：生成的文件名格式为 `{ExtensionName}_{Version}.zip`
-
-
-**示例**：`my-awesome-plugin_1.0.0.0.zip`
+- 把 ZIP 放到 Server 的 `wwwroot/packages/` 目录，更新 `versions.json` 中的 `Url` 和 `Hash`
+- 或上传到 OSS/CDN，把下载链接写入 `oss_config.json`
+- Core Upgrade 进程下载 ZIP 后，`DiffPipeline.DirtyAsync` 根据 `.patch` 和删除清单完成更新
 
 ---
 
-### 依赖关系
+## Extension：打包扩展
 
-#### 依赖项
+### 解决什么问题
 
-**描述**：该扩展所依赖的其他扩展的 ID 列表，多个依赖项用逗号分隔。扩展系统会自动处理依赖关系的解析和安装顺序。
+如果你使用 `GeneralUpdate.Extension` 组件管理插件/扩展，每次发布新扩展都需要手动构建标准格式的 ZIP 包并生成 `manifest.json`。Extension 模块把你从手工压缩和手写 JSON 中解放出来。
 
+### 输入
 
-**格式 Format**：逗号分隔的扩展 GUID 列表
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| Name | ✅ | 扩展唯一标识，建议小写+连字符，如 `my-data-exporter` |
+| Version | ✅ | 语义化版本，如 `1.0.0` |
+| Description | ❌ | 扩展功能描述 |
+| Publisher | ❌ | 发布者名称 |
+| License | ❌ | 许可证标识，如 `MIT` |
+| Extension Directory | ✅ | 扩展源文件目录，点击 Pick 选择文件夹 |
+| Export Directory | ❌ | 输出目录，为空时输出到桌面 |
+| Custom Properties | ❌ | 自定义键值对，写入 `manifest.json.customProperties` |
 
-**示例**：
+### 工具内部做了什么
+
+1. 校验目录存在、version 格式合法。
+2. 将 Extension Directory 中所有文件打包为 ZIP。
+3. 在 ZIP 根目录写入 `manifest.json`。
+
+### 输出
+
 ```
-550e8400-e29b-41d4-a716-446655440001,
-550e8400-e29b-41d4-a716-446655440002
-```
-
-**使用场景
-- 扩展需要其他扩展提供的功能
-- 共享公共库或资源
-- 确保正确的加载顺序
-
----
-
-### 版本兼容性
-
-#### 最小主机版本
-
-**描述**：扩展支持的最低主机应用程序版本。如果主机版本低于此值，扩展将被标记为不兼容。
-
-
-**格式 Format**：语义化版本号（不含构建号）Semantic version number (without build number)
-
-**示例**：`1.0.0`、`2.5.0`
-
----
-
-#### 最大主机版本
-
-**描述**：扩展支持的最高主机应用程序版本。如果主机版本高于此值，扩展将被标记为不兼容。
-
-
-**格式 Format**：语义化版本号（不含构建号）Semantic version number (without build number)
-
-**示例**：`3.0.0`、`2.9.9`
-
-**兼容性检查逻辑 Compatibility Check Logic**：
-```
-MinHostVersion ≤ 主机版本 ≤ MaxHostVersion
-MinHostVersion ≤ Host Version ≤ MaxHostVersion
-```
-
-**示例场景**：
-- 主机版本：`2.0.0`
-- 最小主机版本：`1.5.0`
-- 最大主机版本：`2.5.0`
-- 结果：✓ 兼容 Compatible
-
----
-
-### 平台和格式
-
-#### 格式
-
-**描述**：扩展包的文件格式。目前固定为 `.zip` 格式，这是一个只读字段。
-
-
-**值 Value**：`.zip` （只读 Read-only）
-
----
-
-#### 发布日期
-
-**描述**：扩展的发布日期。用于版本追踪和显示发布时间线。
-
-
-**操作 Operation**：使用日历选择器选择日期
-
----
-
-#### 平台
-
-**描述**：扩展支持的目标操作系统平台。选择正确的平台可以确保扩展仅在兼容的系统上安装和运行。
-
-
-**可选值 Available Options**：
-- `Windows` - 仅支持
-- `Linux` - 仅支持
-- `MacOS` - 仅支持
-
-**选择指南 Selection Guide**：
-- 如果扩展使用了平台特定的 API 或库，选择对应的平台
-- 跨平台扩展可以为每个平台创建单独的版本
-- 平台选择影响扩展在不同操作系统上的可见性和可安装性
-
----
-
-### 选项
-
-#### 预发布版本
-
-**描述**：标记该扩展版本是否为预发布版本（如 Alpha、Beta、RC）。预发布版本通常用于测试和早期访问。
-
-
-**复选框 Checkbox**：勾选表示预发布
-
-**使用场景
-- 内部测试版本
-- 公开测试版本
-- 候选发布版本
-
-**影响 Impact**：
-- 预发布版本可能在扩展市场中单独显示或标记 Pre-release versions may be displayed or marked separately in extension marketplaces
-- 用户可以选择是否接收预发布版本的自动更新
-
----
-
-### 自定义属性
-
-#### 启用自定义属性
-
-**描述**：启用此选项后，可以为扩展添加额外的键值对元数据，用于存储扩展特定的配置或信息。
-
-
-**复选框 Checkbox**：勾选以显示自定义属性输入区域
-
----
-
-#### 添加自定义属性
-
-**操作步骤 Operation Steps**：
-
-1. **输入属性键 Enter Property Key**：在 "Property" 字段中输入属性名称"Property" field
-   - 建议使用驼峰命名法或连字符
-   - 示例：`maxConnections`、`default-theme`、`apiEndpoint`
-
-2. **输入属性值 Enter Property Value**：在 "Value" 字段中输入对应的值"Value" field
-   - 支持字符串、数字等各种值
-   - 示例：`100`、`dark`、`https://api.example.com`
-
-3. **点击添加 Click Add**：点击 "Add" 按钮将属性添加到列表 Click the "Add" button to add the property to the list
-
-4. **管理属性 Manage Properties**：
-   - 查看已添加的属性
-   - 点击 "Remove" 删除不需要的属性 Click "Remove" to delete unwanted properties
-
-**使用场景
-- 存储扩展特定的配置选项 Store extension-specific configuration options
-- 记录扩展的元数据信息
-- 传递初始化参数
-- 存储扩展的 API 端点或资源路径 Store extension API endpoints or resource paths
-
-**示例**：
-```json
-{
-  "maxConcurrentTasks": "5",
-  "defaultLanguage": "en-US",
-  "apiBaseUrl": "https://api.myextension.com",
-  "enableDebugMode": "false"
-}
-```
-
----
-
-## 操作流程
-
-### 创建扩展包的完整步骤
-
-#### 步骤 1：准备扩展文件
-
-确保您的扩展目录包含所有必要的文件：
-- 程序集文件（DLL、可执行文件）
-- 资源文件（图标、模板、配置文件）
-- 依赖库
-- 文档文件（README、LICENSE）
-
----
-
-#### 步骤 2：打开扩展管理器
-
-1. 启动 GeneralUpdate.Tools Launch GeneralUpdate.Tools
-2. 点击顶部的 "Extension" 选项卡 Click the "Extension" tab at the top
-3. 进入扩展管理器界面---
-
-#### 步骤 3：填写基本信息
-
-按照上述字段说明，依次填写：
-- Extension Name（扩展名称）
-- Display Name（显示名称）
-- 版本号
-- 描述
-- 发布者
-- 许可证
-- Categories（分类）
-
-- 扩展名称
-- 显示名称
-- 版本
-- 描述
-- 发布者
-- 许可证
-- 分类
-
----
-
-#### 步骤 4：配置路径
-
-1. **选择扩展目录**：
-   - 点击 "Extension Directory" 旁的 "Pick" 按钮
-   - 浏览并选择包含扩展文件的文件夹
-
-2. **选择导出路径**：
-   - 点击 "Export Path" 旁的 "Pick" 按钮
-   - 选择保存生成的扩展包的目录
-
----
-
-#### 步骤 5：配置依赖和兼容性（可选）
-
-1. **添加依赖项
-   - 在 "Dependencies" 字段中输入依赖扩展的 GUID Enter the GUID of dependent extensions in the "Dependencies" field
-   - 多个依赖项用逗号分隔
-
-2. **设置版本兼容性 Set Version Compatibility**：
-   - 填写 "Min Host Version" Fill in "Min Host Version"
-   - 填写 "Max Host Version" Fill in "Max Host Version"
-
----
-
-#### 步骤 6：选择平台和选项
-
-1. **选择目标平台**：
-   - 从 "Platform" 下拉列表中选择 Windows、Linux 或 MacOS Select Windows, Linux, or MacOS from the "Platform" dropdown list
-
-2. **设置发布日期 Set Release Date**：
-   - 使用日历选择器选择发布日期
-
-3. **标记预发布版本 Mark Pre-release Version**（如果适用 if applicable）：
-   - 勾选 "Pre-release" 复选框 Check the "Pre-release" checkbox
-
----
-
-#### 步骤 7：添加自定义属性（可选）
-
-2. 在输入框中添加键值对
-3. 点击 "Add" 按钮添加每个属性 Click the "Add" button to add each property
-4. 根据需要添加多个自定义属性
-
----
-
-#### 步骤 8：生成扩展包
-
-1. **检查所有信息 Review All Information**：
-   - 确保所有必填字段都已正确填写
-   - 验证路径是否正确
-
-2. **点击 Build 按钮 Click Build Button**：
-   - 点击底部的 "Build" 按钮
-   - 等待打包过程完成
-
-3. **验证成功
-   - 将显示成功消息，包含文件名和位置 A success message will be displayed with the file name and location
-   - 生成的扩展包位于导出路径中
-
----
-
-#### 步骤 9：验证扩展包
-
-生成后，验证扩展包是否包含：
-1. 所有源文件（从扩展目录压缩）
-2. `manifest.json` 文件（自动生成）
-
-可以使用解压缩工具打开 .zip 文件进行检查：
-```
-MyExtension_1.0.0.0.zip
-  ├── manifest.json          ← 扩展元数据 Extension metadata
+{ExportDirectory}/{Name}_{Version}.zip
+  ├── manifest.json               ← 扩展元数据
   ├── bin/
   │   └── MyExtension.dll
   ├── resources/
-  └── README.md
-```
-
----
-
-### 清除表单
-
-如果需要重新开始或清除所有输入的内容：
-1. 点击底部的 "Clear" 按钮 Click the "Clear" button at the bottom
-2. 所有字段将重置为默认值 All fields will be reset to default values
-3. 自定义属性列表将被清空 Custom properties list will be cleared
-
-
----
-
-## 输出结果
-
-### 生成的扩展包结构
-
-扩展管理器生成的 .zip 文件具有以下结构：
-
-
-```
-ExtensionName_Version.zip
-  ├── manifest.json                    ← 扩展元数据 Extension metadata
-  ├── [所有源目录中的文件和文件夹]     ← All files and folders from source directory
   └── ...
 ```
 
----
-
-### manifest.json 文件内容
-
-`manifest.json` 文件包含所有扩展元数据，示例结构：
-
+`manifest.json` 示例：
 
 ```json
 {
-  "Name": "my-awesome-plugin",
-  "DisplayName": "My Awesome Plugin",
-  "Version": "1.0.0.0",
-  "Description": "This extension adds powerful features to your application",
-  "Publisher": "YourCompany",
-  "License": "MIT",
-  "Categories": ["Tools", "Productivity"],
-  "Dependencies": "550e8400-e29b-41d4-a716-446655440001",
-  "MinHostVersion": "1.0.0",
-  "MaxHostVersion": "2.0.0",
-  "Format": ".zip",
-  "ReleaseDate": "2026-02-12T00:00:00",
-  "IsPreRelease": false,
-  "Platform": {
-    "DisplayName": "Windows",
-    "Value": 1
-  },
-  "FileSize": 1048576,
-  "CustomProperties": {
-    "maxConnections": "100",
-    "apiEndpoint": "https://api.example.com"
+  "name": "my-data-exporter",
+  "version": "1.0.0",
+  "description": "Export data to CSV/Excel/JSON",
+  "publisher": "MyCompany",
+  "license": "MIT",
+  "dependencies": "",
+  "minHostVersion": "",
+  "maxHostVersion": "",
+  "isPreRelease": false,
+  "platform": { "displayName": "Windows", "value": 1 },
+  "format": ".zip",
+  "releaseDate": "2026-06-01T00:00:00",
+  "customProperties": { "maxConnections": "100" }
+}
+```
+
+### 下游如何使用
+
+- Extension Host 调用 `ExtensionManager.QueryRemoteExtensionsAsync(...)` 获取扩展列表
+- 安装时下载 ZIP，读取 `manifest.json` 进行兼容性检查和依赖解析
+- 详见 [GeneralUpdate.Extension](./GeneralUpdate.Extension.md)
+
+---
+
+## OSS Config：生成 OSS 版本清单
+
+### 解决什么问题
+
+如果你使用 OSS 模式更新（静态文件服务器），你需要维护一个 `versions.json` 或 `oss_config.json`，让客户端知道有哪些版本可以下载。OSS Config 模块帮你整理版本信息并计算 SHA256。
+
+### 输入
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| PacketName | ✅ | 更新包名称 |
+| Version | ✅ | 语义化版本号 |
+| Url | ✅ | 客户端可下载补丁包的完整地址 |
+| SHA256 | 推荐 | 选择本地 ZIP 文件后点击 ComputeHash 自动计算 |
+
+### 操作流程
+
+1. 填写 PacketName、Version、Url。
+2. 点击 **ComputeHash**，选择本地补丁 ZIP 文件，自动填入 SHA256。
+3. 点击 **Add To List**，加入列表。
+4. 重复以上步骤添加所有版本。
+5. 点击 **Export**，生成 `oss_config.json`。
+
+### 输出
+
+```json
+[
+  {
+    "PacketName": "client_1.0.0_to_2.0.0",
+    "Hash": "f2c7a8b3...",
+    "Version": "2.0.0",
+    "Url": "https://cdn.example.com/client_1.0.0_to_2.0.0.zip",
+    "ReleaseDate": ""
   }
-}
+]
 ```
 
----
+### 下游如何使用
 
-### 字段映射说明
-
-| 界面字段 | JSON 字段 | 数据类型 | 说明 |
-| ----------------------- | -------------------- | ------------------ | ---------------------------------------- |
-|  Extension Name           |  Name                  |  string              | 扩展唯一标识符 |
-|  Display Name             |  DisplayName           |  string              | 显示名称 |
-|  Version                  |  Version               |  string              | 版本号 |
-|  Description              |  Description           |  string              | 扩展描述 |
-|  Publisher                |  Publisher             |  string              | 发布者 |
-|  License                  |  License               |  string              | 许可证 |
-|  Categories               |  Categories            |  array               | 分类列表 |
-|  Dependencies             |  Dependencies          |  string              | 依赖项（逗号分隔）Dependencies (comma-separated) |
-|  Min Host Version         |  MinHostVersion        |  string              | 最小主机版本 |
-|  Max Host Version         |  MaxHostVersion        |  string              | 最大主机版本 |
-|  Format                   |  Format                |  string              | 文件格式 |
-|  Release Date             |  ReleaseDate           |  DateTime            | 发布日期 |
-|  Pre-release              |  IsPreRelease          |  boolean             | 是否预发布 |
-|  Platform                 |  Platform              |  object              | 平台信息 |
-|  Custom Properties        |  CustomProperties      |  object              | 自定义属性字典 |
+- 将 `oss_config.json` 上传到 OSS bucket 或静态文件服务器
+- OSS 客户端读取此文件发现可用版本，下载后校验 Hash
+- 详见 [GeneralClient.OSS](./GeneralClient.OSS.md)
 
 ---
 
-## 最佳实践
+## Config：生成启动清单
 
-### 命名规范
+### 解决什么问题
 
-1. **扩展名称 Extension Name**：
-   - 使用小写字母和连字符
-   - 避免空格和特殊字符
-   - 保持简洁且具有描述性
-   - ✓ 正确 Correct：`data-exporter`、`theme-customizer`
-   - ✗ 错误 Incorrect：`Data Exporter`、`Theme@Customizer`
+Client 和 Upgrade 启动时需要知道主程序名、升级程序名、版本号、ProductId、UpdatePath 等信息。Config 模块从 `.csproj` 中自动提取 AssemblyName 和 TargetFramework，帮你生成 `generalupdate.manifest.json`，省去手写和手误。
 
-2. **版本号 Version Number**：
-   - 遵循语义化版本规范 Follow Semantic Versioning
-   - 格式：`主版本.次版本.修订号.构建号` Format: `Major.Minor.Patch.Build`
-   - 示例：`1.0.0.0`、`2.1.3.5`
+### 输入
 
----
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| Client .csproj | ✅ | 主程序的 `.csproj` 文件路径 |
+| Upgrade .csproj | ❌ | 升级程序的 `.csproj` 路径 |
+| ClientVersion | ✅ | 客户端当前版本，如 `1.0.0` |
+| UpgradeClientVersion | ✅ | 升级程序版本，如 `1.0.0` |
+| AppType | ✅ | Client / Upgrade / OssClient / OssUpgrade |
+| ProductId | ✅ | 产品标识 GUID |
+| UpdatePath | ✅ | 升级程序相对主程序的子目录，如 `update/` |
 
-### 目录组织
+### 操作流程
 
-保持扩展目录结构清晰：
+1. 点击 Browse 选择 Client `.csproj`（必填）和 Upgrade `.csproj`（可选）。
+2. 点击 **Analyze**，工具自动读取 AssemblyName 填入 `MainAppName`、`UpdateAppName`。
+3. 手动填写 Version、AppType、ProductId、UpdatePath。
+4. 点击 **Generate**，在工具运行目录生成 `generalupdate.manifest.json`。
+5. 点击 **Generate Sample**，额外执行 `dotnet publish` 并输出可运行的发布目录。
 
-Maintain a clear extension directory structure:
+### 输出
 
-```
-MyExtension/
-  ├── bin/                    ← 二进制文件 Binary files
-  │   ├── MyExtension.dll
-  │   └── dependencies/
-  ├── resources/              ← 资源文件 Resource files
-  │   ├── icons/
-  │   ├── templates/
-  │   └── localization/
-  ├── docs/                   ← 文档 Documentation
-  │   └── README.md
-  └── LICENSE                 ← 许可证 License
-```
-
----
-
-### 版本兼容性管理
-
-1. **设置合理的版本范围 Set Reasonable Version Range**：
-   - 不要设置过窄的版本范围 Don't set too narrow version range
-   - 考虑向后兼容性
-   - 示例：Min `1.0.0`、Max `2.0.0` (支持 1.x 所有版本)
-
-2. **主版本更新 Major Version Updates**：
-   - 主机应用程序发生重大变化时，更新 Min/Max Host Version
-   - 为新的主版本创建新的扩展版本
-
----
-
-### 依赖管理
-
-1. **最小化依赖 Minimize Dependencies**：
-   - 只声明必需的依赖项
-   - 避免循环依赖
-
-2. **文档化依赖 Document Dependencies**：
-   - 在描述中说明为什么需要这些依赖
-   - 提供依赖项的获取方式
-
----
-
-### 自定义属性使用
-
-1. **使用场景
-   - 存储扩展特定的配置 Store extension-specific configurations
-   - 记录扩展的技术要求
-   - 传递初始化参数
-
-2. **命名建议 Naming Recommendations**：
-   - 使用驼峰命名法 Use camelCase
-   - 保持键名简洁明了
-   - 添加前缀避免冲突
-
----
-
-### 测试和验证
-
-1. **打包前检查 Pre-packaging Checks**：
-   - ✓ 验证所有文件是否完整
-   - ✓ 检查版本号是否正确
-   - ✓ 确认依赖项是否准确
-   - ✓ 测试扩展在目标平台上的运行
-
-2. **打包后验证 Post-packaging Verification**：
-   - ✓ 解压查看文件结构
-   - ✓ 检查 manifest.json 内容 Check manifest.json content
-   - ✓ 验证文件大小是否合理
-   - ✓ 在目标环境中安装测试
----
-
-### 发布管理
-
-1. **预发布版本 Pre-release Versions**：
-   - 使用预发布标记进行内部测试 Use pre-release flag for internal testing
-   - 收集反馈后再发布正式版本
-
-2. **版本更新 Version Updates**：
-   - 保持版本历史记录
-   - 在描述中记录更新日志
-   - 提供从旧版本升级的指导
-
----
-
-## 故障排除
-
-### 常见问题
-
-#### 问题 1：构建失败
-
-**可能原因 Possible Causes**：
-- 扩展目录不存在或无法访问
-- 导出路径无写入权限
-- 磁盘空间不足
-- 扩展目录为空
-
-**解决方案 Solutions**：
-1. 验证扩展目录路径是否正确
-2. 检查导出路径的写入权限
-3. 确保有足够的磁盘空间
-4. 确认扩展目录包含文件
-
----
-
-#### 问题 2：验证错误
-
-**可能原因 Possible Causes**：
-- 必填字段未填写
-- 版本号格式不正确
-- 路径格式无效
-
-**解决方案 Solutions**：
-1. 检查所有必填字段（名称、版本、目录、导出路径）Check all required fields (name, version, directory, export path)
-2. 使用正确的版本号格式（如 `1.0.0.0`）Use correct version number format (e.g., `1.0.0.0`)
-3. 确保路径使用正确的格式
-
----
-
-#### 问题 3：生成的包无法解压
-
-**可能原因 Possible Causes**：
-- 打包过程被中断
-- 磁盘空间在打包过程中耗尽
-- 源文件被锁定或正在使用
-
-**解决方案 Solutions**：
-1. 重新生成扩展包
-2. 确保有足够的磁盘空间
-3. 关闭正在使用扩展文件的程序
-
----
-
-#### 问题 4：自定义属性无法添加
-
-**可能原因 Possible Causes**：
-- 属性键或值为空
-- 属性键已存在
-
-**解决方案 Solutions**：
-1. 确保键和值都已填写
-2. 使用唯一的属性键名
-3. 如需修改现有属性，先删除再重新添加 To modify existing properties, delete and re-add
-
----
-
-### 4. 模拟更新
-
-#### 功能介绍
-
-模拟更新是 GeneralUpdate.Tools 最强大的功能之一，能够在本地完整模拟从客户端到服务端的整个更新流程。开发者无需部署真实服务端即可测试和验证更新逻辑。
-
-**模拟更新会对以下流程进行端到端验证：**
-
-1. **输入校验** — 验证 SemVer 版本格式、目录存在性、.NET SDK 版本
-2. **环境准备** — 准备应用程序目录
-3. **应用发布** — 使用 `dotnet publish` 发布内置的 ClientSample 和 UpgradeSample 测试应用
-4. **清单生成** — 在应用目录生成 `generalupdate.manifest.json`
-5. **Mock 服务端** — 启动本地 ASP.NET Core 模拟更新服务器
-6. **执行更新** — 运行 ClientSample → 下载补丁 → 启动 UpgradeSample → 完成更新
-7. **结果验证** — 检查更新是否成功并生成测试报告
-
-#### 模拟架构
-
-```
-┌───────────────────────────────────────────┐
-│           GeneralUpdate.Tools              │
-│                                            │
-│  ┌─────────────────────────────────────┐  │
-│  │        SimulationService             │  │
-│  │  Step1: Validate                     │  │
-│  │  Step2: Prepare                      │  │
-│  │  Step3: dotnet publish               │  │
-│  │  Step4: Start LocalUpdateServer      │  │
-│  │  Step5: Run ClientSample             │  │
-│  │  Step6: Verify                       │  │
-│  └──────────────┬──────────────────────┘  │
-│                 │                          │
-│  ┌──────────────▼──────────────────────┐  │
-│  │     LocalUpdateServer (Mock API)     │  │
-│  │  POST /Upgrade/Verification          │  │
-│  │  POST /Upgrade/Report                │  │
-│  │  GET  /patch/{filename}              │  │
-│  └─────────────────────────────────────┘  │
-└───────────────────────────────────────────┘
-```
-
-#### 参数说明
-
-| 参数 | 说明 |
-|------|------|
-| 应用目录 | 存放 ClientSample 和 UpgradeSample 的根目录 |
-| 补丁包路径 | 预先准备好的更新补丁包（.zip）路径 |
-| 当前版本 | 模拟的客户端当前版本号 |
-| 目标版本 | 模拟的更新目标版本号 |
-| 平台 | 目标操作系统（Windows / Linux / macOS） |
-| 应用类型 | Client / Upgrade |
-| 应用密钥 | 服务端验证密钥（与 Configinfo.AppSecretKey 对应） |
-| 产品 ID | 产品分支标识 |
-| 更新路径 | 自定义更新路径（可选） |
-| 服务端口 | 本地模拟服务端端口（默认自动选择） |
-
-#### 使用步骤
-
-**步骤 1：准备补丁包**
-
-使用「补丁包」功能或手动准备一个更新补丁包（`.zip`），放到任意目录。
-
-**步骤 2：配置模拟参数**
-
-1. 打开 GeneralUpdate.Tools，切换到「模拟更新」选项卡
-2. 选择应用目录（用于存放测试应用的位置）
-3. 选择补丁包文件
-4. 填写当前版本号（如 `1.0.0.0`）
-5. 填写目标版本号（如 `1.0.1.0`）
-6. 选择目标平台
-7. 选择应用类型（Client）
-8. 填写应用密钥和产品 ID
-
-**步骤 3：启动模拟**
-
-点击「开始模拟」按钮，观察实时日志输出：
-
-```
-[Step 1/6] 验证输入参数...
-  ✓ 版本号格式正确
-  ✓ 目录存在
-  ✓ .NET SDK 10.0.0 已安装
-
-[Step 2/6] 准备应用目录...
-  ✓ 已创建应用目录
-
-[Step 3/6] 发布测试应用...
-  ✓ ClientSample 发布成功
-  ✓ UpgradeSample 发布成功
-
-[Step 4/6] 启动模拟服务器...
-  ✓ 服务器已启动: http://127.0.0.1:50432
-
-[Step 5/6] 运行更新流程...
-  → 客户端连接服务器...
-  → 发现新版本 1.0.1.0
-  → 下载补丁包...
-  → 解压补丁...
-  → 应用差分包...
-  → 启动升级助手...
-  → 文件替换完成
-
-[Step 6/6] 验证更新结果...
-  ✓ 更新成功！
-```
-
-**步骤 4：查看报告**
-
-模拟完成后，工具会生成 `simulation_report.md` 报告文件，包含：
-
-- 模拟配置信息
-- 完整时间线
-- 各步骤详细日志
-- 成功/失败状态
-
----
-
-### 5. 配置生成器
-
-#### 功能介绍
-
-配置生成器是一个开发者效率工具，能够自动分析 `.csproj` 文件并生成 `generalupdate.manifest.json` 配置文件。它消除了手动编写配置文件的繁琐和出错风险。
-
-**核心能力：**
-- 解析 `.csproj` 文件提取 `AssemblyName`、`OutputType`、`TargetFramework`
-- 自动填充应用名称、框架版本等字段
-- 验证 SemVer 版本号格式
-- 生成标准的 `generalupdate.manifest.json`
-- 使用 `dotnet publish` 构建并组装示例项目结构
-
-#### 配置管道
-
-配置生成器内部使用 5 步管道处理：
-
-```
-CsprojParseStep → SemverValidateStep → ManifestBuildStep 
-  → UserConfirmStep → FileEmitStep
-```
-
-| 步骤 | 说明 |
-|------|------|
-| **CsprojParseStep** | 解析 Client 和 Upgrade 的 .csproj 文件，提取项目元数据 |
-| **SemverValidateStep** | 验证 ClientVersion 和 UpgradeClientVersion 是否为有效 SemVer |
-| **ManifestBuildStep** | 将解析结果和用户输入合并，填充 Manifest 模型 |
-| **UserConfirmStep** | 预留步骤，CLI 模式下交互确认；GUI 模式下为 no-op |
-| **FileEmitStep** | 将 Manifest 序列化为 JSON 写入磁盘 |
-
-#### 参数说明
-
-| 参数 | 说明 |
-|------|------|
-| Client 路径 | 客户端项目的 `.csproj` 文件路径（必填） |
-| Upgrade 路径 | 升级助手项目的 `.csproj` 文件路径（可选） |
-| 主应用名称 | 自动从 AssemblyName 提取，可手动覆盖 |
-| 客户端版本 | 客户端当前版本号（SemVer 格式） |
-| 升级应用名称 | 自动从 Upgrade 项目的 AssemblyName 提取 |
-| 升级端版本 | 升级助手当前版本号 |
-| 应用类型 | Client / Upgrade |
-| 产品 ID | 产品分支唯一标识 |
-| 更新路径 | 自定义更新路径（可选） |
-
-#### 使用步骤
-
-**生成清单文件：**
-
-1. 切换到「配置生成」选项卡
-2. 点击「浏览」选择 Client `.csproj` 文件
-3. （可选）选择 Upgrade `.csproj` 文件
-4. 点击「分析」→ 自动提取 `AssemblyName`、`TargetFramework` 等信息
-5. 手动填写版本号、应用类型、产品 ID
-6. 点击「生成」→ `generalupdate.manifest.json` 写入磁盘
-7. 点击「打开目录」查看生成的文件
-
-**生成示例项目结构：**
-
-1. 完成上述步骤 1-5
-2. 点击「生成示例结构」
-3. 工具自动执行 `dotnet publish` 编译 Client 和 Upgrade 项目
-4. 将编译产物和 `manifest.json` 组装为完整的示例目录
-
-#### 生成的 manifest.json 示例
+`generalupdate.manifest.json`：
 
 ```json
 {
-  "MainAppName": "MyApp.exe",
-  "ClientVersion": "1.0.0.0",
-  "AppType": "Client",
-  "UpdateAppName": "UpgradeSample.exe",
-  "UpgradeClientVersion": "1.0.0.0",
-  "ProductId": "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
-  "UpdatePath": ""
+  "mainAppName": "ClientSample.exe",
+  "clientVersion": "1.0.0",
+  "appType": "Client",
+  "updateAppName": "UpgradeSample.exe",
+  "upgradeClientVersion": "1.0.0",
+  "productId": "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
+  "updatePath": "update/"
 }
 ```
 
-#### CsprojInfo 提取规则
+Generate Sample 额外输出：
 
-| .csproj 字段 | 提取目标 |
-|-------------|----------|
-| `<AssemblyName>` | 应用名称（MainAppName / UpdateAppName） |
-| `<OutputType>` | 判断是否为可执行文件 |
-| `<TargetFramework>` | 框架信息（如 net10.0） |
-| 文件名 | fallback 应用名称 |
-
----
-
-## 命令行模式 (CLI)
-
-GeneralUpdate.Tools 的 Pipeline 架构支持命令行模式（开发中）。`UserConfirmStep` 即为 CLI 交互确认预留的步骤。
-
-在 CLI 模式下可以集成到 CI/CD 流程：
-
-```bash
-# 计划中的 CLI 用法
-GeneralUpdate.Tools config generate \
-  --client ./src/MyApp/MyApp.csproj \
-  --upgrade ./src/Upgrade/Upgrade.csproj \
-  --client-version 1.0.0.0 \
-  --product-id "your-product-id" \
-  --output ./manifest.json
+```
+{工具运行目录}/sample_output/
+  ├── ClientSample.exe             ← Client dotnet publish 输出
+  ├── generalupdate.manifest.json
+  └── update/
+      └── UpgradeSample.exe        ← Upgrade dotnet publish 输出
 ```
 
----
+### 下游如何使用
 
-## 相关文档
-
-### GeneralUpdate 生态系统
-
-- **[GeneralUpdate.Core](./GeneralUpdate.Core.md)** - 核心更新组件
-- **[GeneralUpdate.Extension](./GeneralUpdate.Extension.md)** - 扩展管理系统
-- **[GeneralUpdate.ClientCore](./GeneralUpdate.ClientCore.md)** - 客户端更新组件
-- **[快速入门指南](../quickstart/Quik%20start.md)** - GeneralUpdate 快速入门 GeneralUpdate quick start
-
-### 外部资源
-
-- **[GeneralUpdate.Tools 源代码](https://github.com/GeneralLibrary/GeneralUpdate.Tools)** - GitHub 仓库 GitHub 仓库
-- **[GeneralUpdate 主项目](https://github.com/GeneralLibrary/GeneralUpdate)** - 主框架项目
-- **[问题反馈](https://github.com/GeneralLibrary/GeneralUpdate.Tools/issues)** - 报告问题和建议
+- Client 启动时读取 `generalupdate.manifest.json`，配合服务端地址和 AppSecretKey 即可进入更新流程
+- 不需要手写 `Configinfo`，只需用 `GeneralUpdateBootstrap` 读取 manifest
 
 ---
 
-## 适用于
+## Simulation：本地更新仿真
 
-| 产品 | 版本 |
-| ----------------- | ------------------------------------- |
-|  .NET               |  5, 6, 7, 8, 9, 10                      |
-|  .NET Framework     |  4.6.1+                                 |
-|  .NET Standard      |  2.0                                    |
-|  .NET Core          |  2.0+                                   |
-|  Windows            |  10+                                    |
-|  Linux              |  Ubuntu 20.04+, Debian 10+, Fedora 35+  |
-|  macOS              |  10.15+ (Catalina and later)            |
+### 解决什么问题
+
+你刚用 Patch 模块生成了补丁包，但不确定这个包在实际更新流程中能不能跑通。Simulation 模块在你本机启动一个临时更新服务，构建 Client/Upgrade 样例，模拟一次完整的“发现版本 → 下载补丁 → 应用更新”闭环，最后输出 PASS/FAIL 报告。
+
+### 前置条件
+
+- 已安装 .NET 10 SDK（或更高版本）
+- `dotnet --version` 可正常执行
+- 本地 5000 端口未被占用（可配置）
+
+### 输入
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| Old App Directory | ✅ | 模拟用户当前安装的旧版本目录 |
+| Patch File | ✅ | Patch 模块生成的补丁 ZIP |
+| CurrentVersion | ✅ | 旧版本号（Simulation 内部传给 Client，用于版本校验） |
+| TargetVersion | ✅ | 新版本号（Simulation 内部赋值到补丁 ZIP，写入服务端版本源） |
+| AppType | ✅ | ClientApp = 1 / UpgradeApp = 2 |
+| Platform | ✅ | Windows = 1 / Linux = 2 |
+| AppSecretKey | ✅ | 客户端验证密钥 |
+| ProductId | ✅ | 产品标识 GUID |
+| UpdatePath | ✅ | 升级程序子目录名称，如 `update/` |
+| ServerPort | ❌ | 本地服务端口，默认 5000 |
+
+### 仿真过程
+
+1. **校验**：旧目录存在、Patch ZIP 存在、version 格式合法、.NET SDK 可用。
+2. **发布 Client**：`dotnet publish test_app/Client/ClientSample.csproj` 到 App Directory。
+3. **发布 Upgrade**：`dotnet publish test_app/Upgrade/UpgradeSample.csproj` 到 `UpdatePath` 子目录。
+4. **生成 manifest**：在 App Directory 写入 `generalupdate.manifest.json`。
+5. **准备补丁**：把 Patch ZIP 复制到内部 `.server` 目录，计算 SHA256，写入服务端版本源。
+6. **启动服务**：本地服务监听 `http://localhost:{ServerPort}`，提供 `POST /Upgrade/Verification`、`POST /Upgrade/Report`、`GET /patch/{filename}`。
+7. **运行 Client**：启动 `ClientSample.exe`，传入 `--server-url http://localhost:5000 --app-secret ... --client-version 1.0.0`。
+8. **停止服务**：Client 完成更新或超时后停止服务。
+9. **生成报告**：检查目录文件变化，输出 `simulation_report.md`。
+
+### 输出
+
+```
+{AppDirectory}/simulation_report.md    ← 仿真报告（PASS/FAIL + 时间线）
+```
+
+报告包含配置表、PASS/FAIL 结论、Notes 和完整时间线，可以直接贴到发布记录或 CI artifact。
+
+---
+
+## Hash：SHA256 校验
+
+### 解决什么问题
+
+补丁包上传到 CDN/OSS 后，必须确保客户端下载到的文件和原始包一致。Hash 功能对本地文件计算 SHA256，输出小写十六进制字符串，你应该把这个值写入版本清单或服务端返回数据。
+
+### 使用方式
+
+在 **OSS Config** 模块中，点击 **ComputeHash**，选择本地 ZIP 文件，自动填入 SHA256 字段。你也可以单独使用这个功能来校验任何文件。
+
+---
+
+## 推荐发布工作流
+
+这个顺序把六个模块串联成一个完整的发布流水线：
+
+```
+┌─────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐
+│ 发布新旧  │ -> │ Patch    │ -> │ OSS/Hash │ -> │ Config   │ -> │ Simulation│
+│ 版本目录  │    │ 生成补丁  │    │ 算 Hash   │    │ 生成清单  │    │ 本地验证  │
+└─────────┘    └──────────┘    └──────────┘    └──────────┘    └──────────┘
+```
+
+1. **构建发布目录**：在 CI 或本地 `dotnet publish` 得到 old/new 两个目录。
+2. **Patch**：选择 old/new，生成补丁 ZIP。
+3. **OSS Config**：对补丁 ZIP 计算 SHA256，填写下载 URL，导出 `oss_config.json`。（如果使用自建 Server，将相同信息写入 `versions.json`）。
+4. **Config**：选择 Client/Upgrade 的 `.csproj`，生成 `generalupdate.manifest.json`。
+5. **Simulation**：选择旧版本目录和补丁 ZIP，确认 PASS。
+6. **发布上线**：上传补丁 ZIP、OSS 清单到生产环境。
+
+---
+
+## 常见问题
+
+| 现象 | 原因与处理 |
+|------|-----------|
+| Version invalid | 使用 `1.0.0`、`2.0.0-beta.1` 格式。不要用 `1.0` 或 `v1.0.0` |
+| Patch 输出为空或极小 | old/new 目录可能选反，或两个目录内容完全一致。确认 old 是用户已安装版本，new 是目标版本 |
+| 找不到 `delete_files.json` | 当前文件名是 `generalupdate.delete.json`，位于 Patch ZIP 根目录 |
+| Simulation 提示找不到 SDK | 安装 .NET 10 SDK 并确保命令行可执行 `dotnet --version` |
+| Simulation 端口冲突 | 修改 `ServerPort` 或释放本地 5000 端口 |
+| 客户端下载后 Hash 校验失败 | 对**最终上传到 CDN/OSS 的文件**重新计算 Hash，检查是否被中间代理重压缩 |
+| Upgrade 进程没有启动 | 检查 `generalupdate.manifest.json` 中 `updateAppName` 和 `updatePath` 是否与发布目录结构一致 |
+
+---
+
+## 关联文档
+
+- [GeneralUpdate.Core](./GeneralUpdate.Core.md)：Client/Upgrade 更新主流程
+- [GeneralUpdate.Differential](./GeneralUpdate.Differential.md)：差分算法 Clean/Dirty 模式
+- [GeneralUpdate.Extension](./GeneralUpdate.Extension.md)：扩展包安装与版本管理
+- [GeneralClient.OSS](./GeneralClient.OSS.md)：OSS 更新链路
+- [入门实战手册](../quickstart/Beginner cookbook.md)：从零跑通完整更新闭环
+- [高级实战手册](../quickstart/Advanced cookbook.md)：CI/CD 集成与生产发布

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/doc/GeneralUpdate.PacketTool.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/doc/GeneralUpdate.PacketTool.md
@@ -2,882 +2,345 @@
 sidebar_position: 11
 ---
 
-### Introduction
+# GeneralUpdate.Tools
 
-GeneralUpdate.Tools is a desktop application developed using Avalonia that supports Windows / Linux / Mac cross-platform. This tool provides developers with three core functional modules for managing software updates and extensions.
+## What this is
 
-| Repository URL                                        |
-| ----------------------------------------------------- |
-| https://github.com/GeneralLibrary/GeneralUpdate.Tools |
+GeneralUpdate.Tools is a cross-platform desktop application built on Avalonia 12 (Windows / Linux / macOS). It helps you generate and manage patch packages, extension packages, version manifests, and run local update simulations as part of your software release workflow. It does not replace your CI/CD system — it consolidates the repetitive tasks of "package, verify, validate" into a single visual tool.
 
-| Feature                          | Supported | Remarks                                                                                                                               |
-| -------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Build patch package              | Yes       | Compares the previous version with the current version to identify updated, newly added, or deleted files.                            |
-| Build OSS version configuration  | Yes       | Easily generates OSS version configuration files.                                                                                     |
-| Extension Manager                | Yes       | Package and manage application extensions.                                                                                            |
-| Simulate Update                  | Yes       | End-to-end simulation of the full update flow locally.                                                                                |
-| Config Generator                 | Yes       | Analyze .csproj files to auto-generate manifest.json and project structure.                                                           |
+Repository: [https://github.com/GeneralLibrary/GeneralUpdate.Tools](https://github.com/GeneralLibrary/GeneralUpdate.Tools)
 
-![](imgs\tool.png)
+## Download & Run
 
-![](imgs\tool2.png)
+### Option 1: Run from source (recommended for developers)
 
-![](imgs\tool3.png)
+The tool targets .NET 10. Make sure you have [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) installed:
 
----
-
-## Feature Descriptions
-
-### 1. Build Patch Package
-
-#### Function Introduction
-
-The Patch Package Builder is used to create differential update packages. By comparing the old version with the new version, it only packages the changed files, significantly reducing the update package size and download time.
-
-#### Parameter Description
-
-| Name         | Remarks                                                                                                                                                                                                                                                                                        |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Source path  | Path to the folder of the previous version.                                                                                                                                                                                                                                                    |
-| Target path  | Path to the folder of the current version.                                                                                                                                                                                                                                                     |
-| Patch path   | Path where the final update patch package will be generated.                                                                                                                                                                                                                                   |
-| Build        | Recursively compares all project files (DLL, exe, etc.) in the Source path and Target path folders. Analyzes the list of files to be updated through binary difference check and incremental check, then packages the update files according to the folder structure.                         |
-| Clear        | Clears the currently entered content.                                                                                                                                                                                                                                                          |
-
----
-
-### 2. Build OSS Version Configuration
-
-#### Function Introduction
-
-The OSS Version Configuration Builder is used to generate `version.json` configuration files, which contain metadata information about the update package, informing the client application how to obtain and verify the update package.
-
-#### Parameter Description
-
-| Name                | Remarks                                                                       |
-| ------------------- | ----------------------------------------------------------------------------- |
-| Release date time   | Release time of the update package.                                           |
-| PacketName          | Name of the update package.                                                   |
-| Hash                | Hash value of the update package (for integrity verification).                |
-| Version             | Version number of the update package.                                         |
-| Download address    | Download URL of the update package.                                           |
-| Get hash            | Function to retrieve the hash value of the update package.                    |
-| Append              | Appends new update information to the existing version details.               |
-| Clear               | Clears all filled-in content.                                                 |
-| Copy                | Copies the generated content to the clipboard.                                |
-| Build               | Generates the OSS version configuration file (.json) to the local disk.       |
-
----
-
-### 3. Extension Manager
-
-#### Function Introduction
-
-The Extension Manager (ExtensionView) is one of the core features of GeneralUpdate.Tools, used to package application extensions into distributable standard formats. This tool automatically creates extension packages containing all necessary metadata, supports platform-specific configurations, dependency management, and custom properties, making it ideal for building plugin systems and extension marketplaces.
-
-#### Core Features
-
-- **Complete Metadata Management**: Supports standard fields such as extension name, version, description, publisher, license, etc.
-- **Platform Support**: Can specify target platforms (Windows / Linux / MacOS)
-- **Version Compatibility**: Define minimum and maximum host version requirements
-- **Dependency Management**: Declare dependencies on other extensions
-- **Automatic Packaging**: Automatically compress extension directory and generate manifest.json
-- **Custom Properties**: Supports adding additional key-value pair metadata
-- **Category Tags**: Organize and discover extensions through category tags
-
----
-
-## Extension Manager Usage Guide
-
-### Basic Information Fields
-
-#### Extension Name
-
-**Description**: Unique identifier for the extension. It is recommended to use lowercase letters and hyphens without spaces.
-
-**Example**: `my-awesome-plugin`, `data-exporter`
-
----
-
-#### Display Name
-
-**Description**: User-friendly display name that will be shown in extension lists and detail pages.
-
-**Example**: `My Awesome Plugin`, `Data Exporter Tool`
-
----
-
-#### Version
-
-**Description**: Extension version number. It is recommended to follow Semantic Versioning (SemVer) specification in the format `Major.Minor.Patch.Build`.
-
-**Example**: `1.0.0.0`, `2.1.3.0`
-
----
-
-#### Description
-
-**Description**: Detailed description of the extension's functionality, telling users the purpose and features of the extension. Supports multi-line text.
-
-**Example**:
-```
-This extension adds powerful data export capabilities to your application,
-supporting multiple formats including CSV, Excel, and JSON.
+```powershell
+git clone https://github.com/GeneralLibrary/GeneralUpdate.Tools.git
+cd GeneralUpdate.Tools\src
+dotnet run --project GeneralUpdate.Tools.csproj
 ```
 
----
+### Option 2: Download pre-built binaries
 
-#### Publisher
+Go to [GeneralUpdate.Tools Releases](https://github.com/GeneralLibrary/GeneralUpdate.Tools/releases) and download the executable for your platform.
 
-**Description**: Publisher name or organization identifier of the extension.
+> The Simulation module internally runs `dotnet publish` to build test apps, so you need the .NET SDK for that feature. Patch / Extension / OSS / Config modules work without the SDK.
 
-**Example**: `YourCompany`, `john-doe`, `awesome-dev-team`
+## Six modules at a glance
 
----
-
-#### License
-
-**Description**: Open source license identifier used by the extension.
-
-**Example**: `MIT`, `Apache-2.0`, `GPL-3.0`, `BSD-3-Clause`
-
----
-
-#### Categories
-
-**Description**: Category tags to which the extension belongs. Multiple categories are separated by commas. Used for organizing and searching extensions.
-
-**Example**: `Tools, Productivity`, `Data, Export, Utilities`
-
-**Common Categories**:
-- `Tools` - Tools
-- `Productivity` - Productivity enhancement
-- `Data` - Data processing
-- `UI` - User interface
-- `Security` - Security
-- `Development` - Development
+| Module | What you provide | What the tool produces | Downstream consumer |
+|--------|-----------------|----------------------|---------------------|
+| **Patch** | Old version directory + new version directory | `{name}.zip` (contains `.patch` files, new files, `generalupdate.delete.json`) | Server, OSS/CDN, Core Upgrade process |
+| **Extension** | Extension source directory + metadata | `{name}_{version}.zip` (contains `manifest.json`) | `GeneralUpdate.Extension` component |
+| **OSS Config** | Package name, version, download URL, local ZIP (for hash) | `oss_config.json` (version array) | OSS client, object storage publish flow |
+| **Config** | Client/Upgrade `.csproj` files | `generalupdate.manifest.json` + `sample_output/` publish directory | Client/Upgrade bootstrap |
+| **Simulation** | Old version directory + patch ZIP | Local update server + `simulation_report.md` | Pre-release QA gate |
+| **Hash** | Local file (ZIP) | SHA256 lowercase hex string | Integrity check, server-side version records |
 
 ---
 
-### Path Configuration
+## Patch: Generate patch packages
 
-#### Extension Directory
+### What problem it solves
 
-**Description**: Source directory path containing all files of the extension. All files in this directory will be packaged into the final extension package.
+You shipped a new version, but you don't want users to download the entire install package. The Patch module compares old and new version directories and outputs only what changed: modified files become binary `.patch` diffs, new files are copied directly, and deleted files are recorded in a manifest. The resulting differential package is typically much smaller than the full publish directory.
 
-**Operation**: Click the "Pick" button to select a folder
+### Inputs
 
-**Directory Structure Example**:
+| Field | Required | Description |
+|-------|----------|-------------|
+| Old Directory | ✅ | The currently installed old version directory, e.g. `publish\v1.0.0` |
+| New Directory | ✅ | The new version directory to release, e.g. `publish\v2.0.0` |
+| Package Name | ❌ | Output ZIP name (without `.zip`); auto-generated as `patch_yyyyMMddHHmmss` if left empty |
+| Version | ✅ | Target version number in `MAJOR.MINOR.PATCH` format (e.g. `2.0.0`) or `MAJOR.MINOR.PATCH-prerelease+build` |
+| Output Directory | ❌ | Where to save the ZIP; defaults to desktop |
+
+### What the tool does internally
+
+1. Validates that old/new directories exist and version format is correct.
+2. Creates a temp directory `gupatch_yyyyMMddHHmmss`.
+3. Recursively compares old vs new: **changed files** → generate `.patch` binary diff; **new files** → copy directly; **deleted files** → record hash to `generalupdate.delete.json`.
+4. Compresses the temp directory into `{PackageName}.zip`.
+5. Deletes the temp directory; ZIP remains in Output Directory.
+
+Under the hood it calls `GeneralUpdate.Core.Pipeline.DiffPipeline.CleanAsync(oldDir, newDir, patchDir)` — the same code path your CI scripts use.
+
+### Output
+
 ```
-MyExtension/
-  ├── bin/
-  │   ├── MyExtension.dll
-  │   └── dependencies/
-  ├── resources/
-  │   ├── icons/
-  │   └── templates/
-  └── README.md
-```
-
----
-
-#### Export Path
-
-**Description**: Save directory for the final generated extension package (.zip file).
-
-**Operation**: Click the "Pick" button to select save location
-
-**Output Format**: Generated file name format: `{ExtensionName}_{Version}.zip`
-
-**Example**: `my-awesome-plugin_1.0.0.0.zip`
-
----
-
-### Dependencies
-
-#### Dependencies
-
-**Description**: List of IDs of other extensions that this extension depends on, separated by commas. The extension system will automatically handle dependency resolution and installation order.
-
-**Format**: Comma-separated list of extension GUIDs
-
-**Example**:
-```
-550e8400-e29b-41d4-a716-446655440001,
-550e8400-e29b-41d4-a716-446655440002
+{OutputDirectory}/{PackageName}.zip
+  ├── changed.dll.patch           ← binary diff
+  ├── new_file.dll                ← new file (preserving directory structure)
+  └── generalupdate.delete.json    ← deletion manifest
 ```
 
-**Use Cases**:
-- Extension requires functionality provided by other extensions
-- Sharing common libraries or resources
-- Ensuring correct loading order
+### How downstream consumes it
+
+- Place the ZIP in your Server's `wwwroot/packages/` directory and update `Url` and `Hash` in `versions.json`
+- Or upload to OSS/CDN and record the download URL in `oss_config.json`
+- Core Upgrade downloads the ZIP, then `DiffPipeline.DirtyAsync` applies patches and deletions from the manifest
 
 ---
 
-### Version Compatibility
+## Extension: Package extensions
 
-#### Min Host Version
+### What problem it solves
 
-**Description**: Minimum host application version supported by the extension. If the host version is lower than this value, the extension will be marked as incompatible.
+If you use the `GeneralUpdate.Extension` component to manage plugins/extensions, every extension release requires manually building a standard-format ZIP and generating `manifest.json`. The Extension module saves you from manual compression and hand-written JSON.
 
-**Format**: Semantic version number (without build number)
+### Inputs
 
-**Example**: `1.0.0`, `2.5.0`
+| Field | Required | Description |
+|-------|----------|-------------|
+| Name | ✅ | Unique extension identifier (lowercase + hyphens recommended), e.g. `my-data-exporter` |
+| Version | ✅ | Semantic version, e.g. `1.0.0` |
+| Description | ❌ | What the extension does |
+| Publisher | ❌ | Publisher name |
+| License | ❌ | License identifier, e.g. `MIT` |
+| Extension Directory | ✅ | Source directory containing all extension files; click Pick to select |
+| Export Directory | ❌ | Output directory; defaults to desktop |
+| Custom Properties | ❌ | Key-value pairs written to `manifest.json.customProperties` |
 
----
+### Output
 
-#### Max Host Version
-
-**Description**: Maximum host application version supported by the extension. If the host version is higher than this value, the extension will be marked as incompatible.
-
-**Format**: Semantic version number (without build number)
-
-**Example**: `3.0.0`, `2.9.9`
-
-**Compatibility Check Logic**:
 ```
-MinHostVersion ≤ Host Version ≤ MaxHostVersion
-```
-
-**Example Scenario**:
-- Host Version: `2.0.0`
-- Min Host Version: `1.5.0`
-- Max Host Version: `2.5.0`
-- Result: ✓ Compatible
-
----
-
-### Platform and Format
-
-#### Format
-
-**Description**: File format of the extension package. Currently fixed as `.zip` format, this is a read-only field.
-
-**Value**: `.zip` (Read-only)
-
----
-
-#### Release Date
-
-**Description**: Release date of the extension. Used for version tracking and displaying release timeline.
-
-**Operation**: Use the calendar picker to select a date
-
----
-
-#### Platform
-
-**Description**: Target operating system platform supported by the extension. Selecting the correct platform ensures that the extension is only installed and run on compatible systems.
-
-**Available Options**:
-- `Windows` - Only supports Windows operating system
-- `Linux` - Only supports Linux operating system
-- `MacOS` - Only supports MacOS operating system
-
-**Selection Guide**:
-- If the extension uses platform-specific APIs or libraries, select the corresponding platform
-- Cross-platform extensions can create separate versions for each platform
-- Platform selection affects the visibility and installability of extensions on different operating systems
-
----
-
-### Options
-
-#### Pre-release
-
-**Description**: Mark whether this extension version is a pre-release version (such as Alpha, Beta, RC). Pre-release versions are typically used for testing and early access.
-
-**Checkbox**: Check to indicate pre-release
-
-**Use Cases**:
-- Internal test version
-- Public beta version
-- Release candidate version
-
-**Impact**:
-- Pre-release versions may be displayed or marked separately in extension marketplaces
-- Users can choose whether to receive automatic updates for pre-release versions
-
----
-
-### Custom Properties
-
-#### Enable Custom Properties
-
-**Description**: When enabled, you can add additional key-value pair metadata for the extension, used to store extension-specific configurations or information.
-
-**Checkbox**: Check to show custom properties input area
-
----
-
-#### Add Custom Properties
-
-**Operation Steps**:
-
-1. **Enter Property Key**: Enter the property name in the "Property" field
-   - Recommended to use camelCase or hyphen-case
-   - Examples: `maxConnections`, `default-theme`, `apiEndpoint`
-
-2. **Enter Property Value**: Enter the corresponding value in the "Value" field
-   - Supports strings, numbers, and various other values
-   - Examples: `100`, `dark`, `https://api.example.com`
-
-3. **Click Add**: Click the "Add" button to add the property to the list
-
-4. **Manage Properties**:
-   - View added properties
-   - Click "Remove" to delete unwanted properties
-
-**Use Cases**:
-- Store extension-specific configuration options
-- Record extension metadata information
-- Pass initialization parameters
-- Store extension API endpoints or resource paths
-
-**Examples**:
-```json
-{
-  "maxConcurrentTasks": "5",
-  "defaultLanguage": "en-US",
-  "apiBaseUrl": "https://api.myextension.com",
-  "enableDebugMode": "false"
-}
-```
-
----
-
-## Operation Workflow
-
-### Complete Steps to Create an Extension Package
-
-#### Step 1: Prepare Extension Files
-
-Ensure your extension directory contains all necessary files:
-- Assembly files (DLLs, executables)
-- Resource files (icons, templates, configuration files)
-- Dependency libraries
-- Documentation files (README, LICENSE)
-
----
-
-#### Step 2: Open Extension Manager
-
-1. Launch GeneralUpdate.Tools
-2. Click the "Extension" tab at the top
-3. Enter the Extension Manager interface
-
----
-
-#### Step 3: Fill in Basic Information
-
-Fill in the following fields according to the field descriptions above:
-- Extension Name
-- Display Name
-- Version
-- Description
-- Publisher
-- License
-- Categories
-
----
-
-#### Step 4: Configure Paths
-
-1. **Select Extension Directory**:
-   - Click the "Pick" button next to "Extension Directory"
-   - Browse and select the folder containing extension files
-
-2. **Select Export Path**:
-   - Click the "Pick" button next to "Export Path"
-   - Select the directory to save the generated extension package
-
----
-
-#### Step 5: Configure Dependencies and Compatibility (Optional)
-
-1. **Add Dependencies** (if applicable):
-   - Enter the GUID of dependent extensions in the "Dependencies" field
-   - Separate multiple dependencies with commas
-
-2. **Set Version Compatibility**:
-   - Fill in "Min Host Version"
-   - Fill in "Max Host Version"
-
----
-
-#### Step 6: Select Platform and Options
-
-1. **Select Target Platform**:
-   - Select Windows, Linux, or MacOS from the "Platform" dropdown list
-
-2. **Set Release Date**:
-   - Use the calendar picker to select the release date
-
-3. **Mark Pre-release Version** (if applicable):
-   - Check the "Pre-release" checkbox
-
----
-
-#### Step 7: Add Custom Properties (Optional)
-
-1. Check "Enable Custom Properties"
-2. Add key-value pairs in the input boxes
-3. Click the "Add" button to add each property
-4. Add multiple custom properties as needed
-
----
-
-#### Step 8: Build Extension Package
-
-1. **Review All Information**:
-   - Ensure all required fields are correctly filled in
-   - Verify that paths are correct
-
-2. **Click Build Button**:
-   - Click the "Build" button at the bottom
-   - Wait for the packaging process to complete
-
-3. **Verify Success**:
-   - A success message will be displayed with the file name and location
-   - The generated extension package is located in the export path
-
----
-
-#### Step 9: Verify Extension Package
-
-After generation, verify that the extension package contains:
-1. All source files (compressed from extension directory)
-2. `manifest.json` file (automatically generated)
-
-You can open the .zip file with a decompression tool to inspect:
-```
-MyExtension_1.0.0.0.zip
-  ├── manifest.json          ← Extension metadata
+{ExportDirectory}/{Name}_{Version}.zip
+  ├── manifest.json               ← extension metadata
   ├── bin/
   │   └── MyExtension.dll
   ├── resources/
-  └── README.md
-```
-
----
-
-### Clear Form
-
-If you need to start over or clear all entered content:
-1. Click the "Clear" button at the bottom
-2. All fields will be reset to default values
-3. Custom properties list will be cleared
-
----
-
-## Output Results
-
-### Generated Extension Package Structure
-
-The .zip file generated by the Extension Manager has the following structure:
-
-```
-ExtensionName_Version.zip
-  ├── manifest.json                    ← Extension metadata
-  ├── [All files and folders from source directory]
   └── ...
 ```
 
----
-
-### manifest.json File Content
-
-The `manifest.json` file contains all extension metadata. Example structure:
+Example `manifest.json`:
 
 ```json
 {
-  "Name": "my-awesome-plugin",
-  "DisplayName": "My Awesome Plugin",
-  "Version": "1.0.0.0",
-  "Description": "This extension adds powerful features to your application",
-  "Publisher": "YourCompany",
-  "License": "MIT",
-  "Categories": ["Tools", "Productivity"],
-  "Dependencies": "550e8400-e29b-41d4-a716-446655440001",
-  "MinHostVersion": "1.0.0",
-  "MaxHostVersion": "2.0.0",
-  "Format": ".zip",
-  "ReleaseDate": "2026-02-12T00:00:00",
-  "IsPreRelease": false,
-  "Platform": {
-    "DisplayName": "Windows",
-    "Value": 1
-  },
-  "FileSize": 1048576,
-  "CustomProperties": {
-    "maxConnections": "100",
-    "apiEndpoint": "https://api.example.com"
-  }
+  "name": "my-data-exporter",
+  "version": "1.0.0",
+  "description": "Export data to CSV/Excel/JSON",
+  "publisher": "MyCompany",
+  "license": "MIT",
+  "dependencies": "",
+  "minHostVersion": "",
+  "maxHostVersion": "",
+  "isPreRelease": false,
+  "platform": { "displayName": "Windows", "value": 1 },
+  "format": ".zip",
+  "releaseDate": "2026-06-01T00:00:00",
+  "customProperties": { "maxConnections": "100" }
 }
 ```
 
----
+### How downstream consumes it
 
-### Field Mapping Description
-
-| UI Field            | JSON Field       | Data Type | Description                            |
-| ------------------- | ---------------- | --------- | -------------------------------------- |
-| Extension Name      | Name             | string    | Extension unique identifier            |
-| Display Name        | DisplayName      | string    | Display name                           |
-| Version             | Version          | string    | Version number                         |
-| Description         | Description      | string    | Extension description                  |
-| Publisher           | Publisher        | string    | Publisher                              |
-| License             | License          | string    | License                                |
-| Categories          | Categories       | array     | Category list                          |
-| Dependencies        | Dependencies     | string    | Dependencies (comma-separated)         |
-| Min Host Version    | MinHostVersion   | string    | Minimum host version                   |
-| Max Host Version    | MaxHostVersion   | string    | Maximum host version                   |
-| Format              | Format           | string    | File format                            |
-| Release Date        | ReleaseDate      | DateTime  | Release date                           |
-| Pre-release         | IsPreRelease     | boolean   | Is pre-release                         |
-| Platform            | Platform         | object    | Platform information                   |
-| Custom Properties   | CustomProperties | object    | Custom properties dictionary           |
+- Extension Host calls `ExtensionManager.QueryRemoteExtensionsAsync(...)` to list available extensions
+- On install, downloads the ZIP, reads `manifest.json` for compatibility checks and dependency resolution
+- See [GeneralUpdate.Extension](./GeneralUpdate.Extension.md) for details
 
 ---
 
-## Best Practices
+## OSS Config: Generate OSS version manifest
 
-### Naming Conventions
+### What problem it solves
 
-1. **Extension Name**:
-   - Use lowercase letters and hyphens
-   - Avoid spaces and special characters
-   - Keep it concise and descriptive
-   - ✓ Correct: `data-exporter`, `theme-customizer`
-   - ✗ Incorrect: `Data Exporter`, `Theme@Customizer`
+If you use OSS mode updates (static file server), you need to maintain a `versions.json` or `oss_config.json` so clients can discover available versions. The OSS Config module helps you organize version metadata and compute SHA256 hashes.
 
-2. **Version Number**:
-   - Follow Semantic Versioning
-   - Format: `Major.Minor.Patch.Build`
-   - Example: `1.0.0.0`, `2.1.3.5`
+### Inputs
 
----
+| Field | Required | Description |
+|-------|----------|-------------|
+| PacketName | ✅ | Update package name |
+| Version | ✅ | Semantic version number |
+| Url | ✅ | Full download URL clients can use |
+| SHA256 | Recommended | Click ComputeHash and select a local ZIP to auto-fill |
 
-### Directory Organization
+### Workflow
 
-Maintain a clear extension directory structure:
+1. Fill in PacketName, Version, Url.
+2. Click **ComputeHash**, select the local patch ZIP, SHA256 auto-fills.
+3. Click **Add To List** to add the entry.
+4. Repeat for all versions.
+5. Click **Export** to generate `oss_config.json`.
 
-```
-MyExtension/
-  ├── bin/                    ← Binary files
-  │   ├── MyExtension.dll
-  │   └── dependencies/
-  ├── resources/              ← Resource files
-  │   ├── icons/
-  │   ├── templates/
-  │   └── localization/
-  ├── docs/                   ← Documentation
-  │   └── README.md
-  └── LICENSE                 ← License
+### Output
+
+```json
+[
+  {
+    "PacketName": "client_1.0.0_to_2.0.0",
+    "Hash": "f2c7a8b3...",
+    "Version": "2.0.0",
+    "Url": "https://cdn.example.com/client_1.0.0_to_2.0.0.zip",
+    "ReleaseDate": ""
+  }
+]
 ```
 
----
+### How downstream consumes it
 
-### Version Compatibility Management
-
-1. **Set Reasonable Version Range**:
-   - Don't set too narrow version range
-   - Consider backward compatibility
-   - Example: Min `1.0.0`, Max `2.0.0` (Support all 1.x versions)
-
-2. **Major Version Updates**:
-   - When major changes occur in the host application, update Min/Max Host Version
-   - Create new extension versions for new major versions
+- Upload `oss_config.json` to your OSS bucket or static file server
+- OSS client reads this file to discover versions and validates Hash after download
+- See [GeneralClient.OSS](./GeneralClient.OSS.md)
 
 ---
 
-### Dependency Management
+## Config: Generate bootstrap manifest
 
-1. **Minimize Dependencies**:
-   - Only declare necessary dependencies
-   - Avoid circular dependencies
+### What problem it solves
 
-2. **Document Dependencies**:
-   - Explain in the description why these dependencies are needed
-   - Provide ways to obtain dependencies
+Client and Upgrade need to know the main app name, updater app name, version, ProductId, and UpdatePath at startup. The Config module reads your `.csproj` files to auto-extract AssemblyName and TargetFramework, then generates `generalupdate.manifest.json` — saving you from manual configuration and typos.
 
----
+### Inputs
 
-### Custom Properties Usage
+| Field | Required | Description |
+|-------|----------|-------------|
+| Client .csproj | ✅ | Path to the main app's `.csproj` file |
+| Upgrade .csproj | ❌ | Path to the updater app's `.csproj` |
+| ClientVersion | ✅ | Current client version, e.g. `1.0.0` |
+| UpgradeClientVersion | ✅ | Updater version, e.g. `1.0.0` |
+| AppType | ✅ | Client / Upgrade / OssClient / OssUpgrade |
+| ProductId | ✅ | Product identifier GUID |
+| UpdatePath | ✅ | Relative subdirectory for Upgrade, e.g. `update/` |
 
-1. **Use Cases**:
-   - Store extension-specific configurations
-   - Record technical requirements of the extension
-   - Pass initialization parameters
+### Workflow
 
-2. **Naming Recommendations**:
-   - Use camelCase
-   - Keep key names concise and clear
-   - Add prefixes to avoid conflicts
+1. Click Browse to select Client `.csproj` (required) and Upgrade `.csproj` (optional).
+2. Click **Analyze** — the tool extracts AssemblyName and fills `MainAppName` / `UpdateAppName`.
+3. Fill in Version, AppType, ProductId, UpdatePath manually.
+4. Click **Generate** to produce `generalupdate.manifest.json` in the tool's run directory.
+5. Click **Generate Sample** to additionally run `dotnet publish` and produce a runnable output directory.
 
----
+### Output
 
-### Testing and Validation
+`generalupdate.manifest.json`:
 
-1. **Pre-packaging Checks**:
-   - ✓ Verify all files are complete
-   - ✓ Check version number is correct
-   - ✓ Confirm dependencies are accurate
-   - ✓ Test extension runs on target platform
-
-2. **Post-packaging Verification**:
-   - ✓ Extract and view file structure
-   - ✓ Check manifest.json content
-   - ✓ Verify file size is reasonable
-   - ✓ Install and test in target environment
-
----
-
-### Release Management
-
-1. **Pre-release Versions**:
-   - Use pre-release flag for internal testing
-   - Collect feedback before releasing stable version
-
-2. **Version Updates**:
-   - Maintain version history
-   - Record changelog in description
-   - Provide upgrade guidance from old versions
-
----
-
-## Troubleshooting
-
-### Common Issues
-
-#### Issue 1: Build Failed
-
-**Possible Causes**:
-- Extension directory does not exist or is inaccessible
-- No write permission for export path
-- Insufficient disk space
-- Extension directory is empty
-
-**Solutions**:
-1. Verify the extension directory path is correct
-2. Check write permissions for the export path
-3. Ensure sufficient disk space
-4. Confirm the extension directory contains files
-
----
-
-#### Issue 2: Validation Error
-
-**Possible Causes**:
-- Required fields not filled
-- Version number format is incorrect
-- Invalid path format
-
-**Solutions**:
-1. Check all required fields (name, version, directory, export path)
-2. Use correct version number format (e.g., `1.0.0.0`)
-3. Ensure paths use correct format
-
----
-
-#### Issue 3: Generated Package Cannot Be Extracted
-
-**Possible Causes**:
-- Packaging process was interrupted
-- Disk space exhausted during packaging
-- Source files are locked or in use
-
-**Solutions**:
-1. Regenerate the extension package
-2. Ensure sufficient disk space
-3. Close programs using extension files
-
----
-
-#### Issue 4: Cannot Add Custom Properties
-
-**Possible Causes**:
-- Property key or value is empty
-- Property key already exists
-
-**Solutions**:
-1. Ensure both key and value are filled
-2. Use unique property key names
-3. To modify existing properties, delete and re-add
-
----
-
-### 4. Simulate Update
-
-#### Overview
-
-Simulate Update is one of GeneralUpdate.Tools' most powerful features, enabling a complete end-to-end simulation of the update flow locally. Developers can test and validate update logic without deploying a real server.
-
-**The simulation validates the following pipeline:**
-
-1. **Validate** — SemVer format, directory existence, .NET SDK version
-2. **Prepare** — Set up the app directory
-3. **Publish** — `dotnet publish` the built-in ClientSample and UpgradeSample
-4. **Generate Manifest** — Create `generalupdate.manifest.json` in the app directory
-5. **Mock Server** — Start an in-process ASP.NET Core mock update server
-6. **Run Update** — ClientSample connects → downloads patch → launches UpgradeSample → completes update
-7. **Verify** — Check update result and generate test report
-
-#### Simulation Architecture
-
-```
-┌───────────────────────────────────────────┐
-│           GeneralUpdate.Tools              │
-│                                            │
-│  ┌─────────────────────────────────────┐  │
-│  │        SimulationService             │  │
-│  │  Step1: Validate                     │  │
-│  │  Step2: Prepare                      │  │
-│  │  Step3: dotnet publish               │  │
-│  │  Step4: Start LocalUpdateServer      │  │
-│  │  Step5: Run ClientSample             │  │
-│  │  Step6: Verify                       │  │
-│  └──────────────┬──────────────────────┘  │
-│                 │                          │
-│  ┌──────────────▼──────────────────────┐  │
-│  │     LocalUpdateServer (Mock API)     │  │
-│  │  POST /Upgrade/Verification          │  │
-│  │  POST /Upgrade/Report                │  │
-│  │  GET  /patch/{filename}              │  │
-│  └─────────────────────────────────────┘  │
-└───────────────────────────────────────────┘
+```json
+{
+  "mainAppName": "ClientSample.exe",
+  "clientVersion": "1.0.0",
+  "appType": "Client",
+  "updateAppName": "UpgradeSample.exe",
+  "upgradeClientVersion": "1.0.0",
+  "productId": "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
+  "updatePath": "update/"
+}
 ```
 
-#### Parameters
-
-| Parameter | Description |
-|-----------|-------------|
-| App Directory | Root directory for ClientSample and UpgradeSample |
-| Patch File Path | Pre-built update patch package (.zip) |
-| Current Version | Simulated client current version |
-| Target Version | Simulated update target version |
-| Platform | Target OS (Windows / Linux / macOS) |
-| App Type | Client / Upgrade |
-| App Secret Key | Server verification key |
-| Product ID | Product branch identifier |
-| Update Path | Custom update path (optional) |
-| Server Port | Local mock server port (auto-selected by default) |
-
-#### Usage Steps
-
-1. Prepare a patch package using the Patch Package tab or manually
-2. Switch to the "Simulate Update" tab
-3. Configure all parameters
-4. Click "Start Simulation"
-5. Watch real-time log output showing each step
-6. Review the generated `simulation_report.md`
-
----
-
-### 5. Config Generator
-
-#### Overview
-
-The Config Generator is a developer productivity tool that analyzes `.csproj` files and auto-generates `generalupdate.manifest.json` configuration files. It eliminates manual configuration errors.
-
-**Core capabilities:**
-- Parse `.csproj` to extract `AssemblyName`, `OutputType`, `TargetFramework`
-- Auto-fill app name, framework version fields
-- Validate SemVer version format
-- Generate standard `generalupdate.manifest.json`
-- Use `dotnet publish` to build and assemble sample project structure
-
-#### Config Pipeline
-
-The generator uses a 5-step pipeline:
+Generate Sample additionally outputs:
 
 ```
-CsprojParseStep → SemverValidateStep → ManifestBuildStep 
-  → UserConfirmStep → FileEmitStep
-```
-
-| Step | Description |
-|------|-------------|
-| **CsprojParseStep** | Parse Client and Upgrade .csproj files, extract project metadata |
-| **SemverValidateStep** | Validate ClientVersion and UpgradeClientVersion as valid SemVer |
-| **ManifestBuildStep** | Merge parsed data with user input into Manifest model |
-| **UserConfirmStep** | Reserved for CLI interactive confirmation (no-op in GUI) |
-| **FileEmitStep** | Serialize Manifest to JSON and write to disk |
-
-#### Parameters
-
-| Parameter | Description |
-|-----------|-------------|
-| Client Path | Client project `.csproj` file path (required) |
-| Upgrade Path | Upgrade project `.csproj` file path (optional) |
-| Main App Name | Auto-extracted from AssemblyName, can override |
-| Client Version | Client current version (SemVer format) |
-| Upgrade App Name | Auto-extracted from Upgrade project's AssemblyName |
-| Upgrade Client Version | Upgrade program current version |
-| App Type | Client / Upgrade |
-| Product ID | Product branch unique identifier |
-| Update Path | Custom update path (optional) |
-
-#### Usage Steps
-
-**Generate manifest:**
-1. Switch to "Config Generator" tab
-2. Browse for Client `.csproj` (required)
-3. Browse for Upgrade `.csproj` (optional)
-4. Click "Analyze" → auto-extracts AssemblyName, TargetFramework
-5. Fill in version, app type, product ID
-6. Click "Generate" → `generalupdate.manifest.json` written to disk
-
-**Generate sample structure:**
-1. Complete steps 1-5 above
-2. Click "Generate Sample Structure"
-3. Tool runs `dotnet publish` for both projects
-4. Assembles outputs with manifest into a complete sample directory
-
----
-
-## Command Line (CLI)
-
-GeneralUpdate.Tools' Pipeline architecture supports CLI mode (in development). The `UserConfirmStep` is reserved for CLI interaction.
-
-Planned CLI usage for CI/CD integration:
-
-```bash
-GeneralUpdate.Tools config generate \
-  --client ./src/MyApp/MyApp.csproj \
-  --upgrade ./src/Upgrade/Upgrade.csproj \
-  --client-version 1.0.0.0 \
-  --product-id "your-product-id" \
-  --output ./manifest.json
+{tool-run-dir}/sample_output/
+  ├── ClientSample.exe             ← Client dotnet publish output
+  ├── generalupdate.manifest.json
+  └── update/
+      └── UpgradeSample.exe        ← Upgrade dotnet publish output
 ```
 
 ---
 
-## Related Documentation
+## Simulation: Local update dry-run
 
-### GeneralUpdate Ecosystem
+### What problem it solves
 
-- **[GeneralUpdate.Core](./GeneralUpdate.Core.md)** - Core update component
-- **[GeneralUpdate.Extension](./GeneralUpdate.Extension.md)** - Extension management system
-- **[GeneralUpdate.ClientCore](./GeneralUpdate.ClientCore.md)** - Client update component
-- **[Quick Start Guide](../quickstart/Quik%20start.md)** - GeneralUpdate quick start
+You just used the Patch module to generate a package — but you're not sure it actually works in a real update flow. The Simulation module starts a local update server, builds Client/Upgrade samples, and runs a complete "discover version → download patch → apply update" loop on your machine, then outputs a PASS/FAIL report.
 
-### External Resources
+### Prerequisites
 
-- **[GeneralUpdate.Tools Source Code](https://github.com/GeneralLibrary/GeneralUpdate.Tools)** - GitHub repository
-- **[GeneralUpdate Main Project](https://github.com/GeneralLibrary/GeneralUpdate)** - Main framework project
-- **[Issue Feedback](https://github.com/GeneralLibrary/GeneralUpdate.Tools/issues)** - Report issues and suggestions
+- .NET 10 SDK (or newer) installed
+- `dotnet --version` works
+- Local port 5000 available (configurable)
+
+### Inputs
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| Old App Directory | ✅ | The directory simulating the user's currently installed version |
+| Patch File | ✅ | The patch ZIP produced by the Patch module |
+| CurrentVersion | ✅ | Old version number (used by the simulated Client for version check) |
+| TargetVersion | ✅ | New version number (used for the server-side version source) |
+| AppType | ✅ | ClientApp = 1 / UpgradeApp = 2 |
+| Platform | ✅ | Windows = 1 / Linux = 2 |
+| AppSecretKey | ✅ | Client authentication key |
+| ProductId | ✅ | Product identifier GUID |
+| UpdatePath | ✅ | Upgrade subdirectory name, e.g. `update/` |
+| ServerPort | ❌ | Local server port, defaults to 5000 |
+
+### Simulation process
+
+1. **Validate**: old directory exists, patch ZIP exists, version format valid, .NET SDK available.
+2. **Publish Client**: `dotnet publish test_app/Client/ClientSample.csproj` to App Directory.
+3. **Publish Upgrade**: `dotnet publish test_app/Upgrade/UpgradeSample.csproj` to `UpdatePath` subdirectory.
+4. **Generate manifest**: write `generalupdate.manifest.json` in App Directory.
+5. **Prepare patch**: copy patch ZIP to internal `.server` directory, compute SHA256, write server-side version source.
+6. **Start server**: local server listens on `http://localhost:{ServerPort}`, serving `POST /Upgrade/Verification`, `POST /Upgrade/Report`, `GET /patch/{filename}`.
+7. **Run Client**: launch `ClientSample.exe` with `--server-url http://localhost:5000 --app-secret ... --client-version 1.0.0`.
+8. **Stop server**: stop after Client completes or times out.
+9. **Generate report**: inspect directory changes and output `simulation_report.md`.
+
+### Output
+
+```
+{AppDirectory}/simulation_report.md    ← simulation report (PASS/FAIL + timeline)
+```
+
+The report includes a config table, PASS/FAIL verdict, notes, and a full timeline — suitable for pasting into release notes or CI artifacts.
 
 ---
 
-## Applicable To
+## Hash: SHA256 verification
 
-| Product         | Versions                              |
-| --------------- | ------------------------------------- |
-| .NET            | 5, 6, 7, 8, 9, 10                     |
-| .NET Framework  | 4.6.1+                                |
-| .NET Standard   | 2.0                                   |
-| .NET Core       | 2.0+                                  |
-| Windows         | 10+                                   |
-| Linux           | Ubuntu 20.04+, Debian 10+, Fedora 35+ |
-| macOS           | 10.15+ (Catalina and later)           |
+### What problem it solves
+
+After uploading a patch package to CDN/OSS, you must ensure clients download the exact same file. The Hash feature computes SHA256 of a local file and outputs a lowercase hex string. You should write this value into your version manifest or server response data.
+
+### How to use
+
+In the **OSS Config** module, click **ComputeHash**, select a local ZIP file, and the SHA256 field auto-fills. You can also use this standalone to verify any file.
+
+---
+
+## Recommended release workflow
+
+This sequence chains the six modules into a complete release pipeline:
+
+```
+┌─────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐
+│ Build    │ -> │ Patch    │ -> │ OSS/Hash │ -> │ Config   │ -> │ Simulation│
+│ old & new│    │ generate │    │ compute  │    │ generate │    │ verify    │
+└─────────┘    └──────────┘    └──────────┘    └──────────┘    └──────────┘
+```
+
+1. **Build release directories**: run `dotnet publish` in CI or locally to get old/new directories.
+2. **Patch**: select old/new, generate patch ZIP.
+3. **OSS Config**: compute SHA256 on the patch ZIP, fill in download URL, export `oss_config.json` (or write the same info to `versions.json` for a self-hosted Server).
+4. **Config**: select Client/Upgrade `.csproj` files, generate `generalupdate.manifest.json`.
+5. **Simulation**: select the old version directory and patch ZIP, confirm PASS.
+6. **Ship**: upload patch ZIP and OSS manifest to production.
+
+---
+
+## FAQ
+
+| Symptom | Cause & fix |
+|---------|------------|
+| Version invalid | Use `1.0.0` or `2.0.0-beta.1` format. Do not use `1.0` or `v1.0.0` |
+| Patch output empty or tiny | old/new directories may be swapped, or the two are identical. Confirm old is the installed version and new is the target version |
+| Cannot find `delete_files.json` | The current filename is `generalupdate.delete.json`, located in the patch ZIP root |
+| Simulation complains about missing SDK | Install .NET 10 SDK and verify `dotnet --version` works |
+| Simulation port conflict | Change `ServerPort` or free up local port 5000 |
+| Hash mismatch after client download | Re-compute hash on the file that was actually uploaded to CDN/OSS; check for proxy re-compression |
+| Upgrade process doesn't start | Verify `updateAppName` and `updatePath` in `generalupdate.manifest.json` match the publish directory structure |
+
+---
+
+## Related docs
+
+- [GeneralUpdate.Core](./GeneralUpdate.Core.md): Client/Upgrade main update flow
+- [GeneralUpdate.Differential](./GeneralUpdate.Differential.md): Differential algorithm Clean/Dirty modes
+- [GeneralUpdate.Extension](./GeneralUpdate.Extension.md): Extension install and version management
+- [GeneralClient.OSS](./GeneralClient.OSS.md): OSS update flow
+- [Beginner cookbook](../quickstart/Beginner cookbook.md): Complete end-to-end update walkthrough
+- [Advanced cookbook](../quickstart/Advanced cookbook.md): CI/CD integration and production releases

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/doc/GeneralUpdate.PacketTool.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/doc/GeneralUpdate.PacketTool.md
@@ -2,766 +2,356 @@
 sidebar_position: 11
 ---
 
-### 简介
+# GeneralUpdate.Tools
 
-GeneralUpdate.Tools 是一款使用 Avalonia 开发的桌面应用程序，支持 Windows / Linux / Mac 跨平台。该工具为开发者提供了三个核心功能模块，用于管理软件更新和扩展。
+## 这是什么
 
+GeneralUpdate.Tools 是一个基于 Avalonia 12 开发的跨平台桌面工具（Windows / Linux / macOS），用于在软件发布流程中生成和管理补丁包、扩展包、版本清单以及执行本地更新仿真。它不替代你的 CI/CD 系统，而是把“打包、校验、验证”这些重复劳动收敛到一个可视化工具中。
 
-| 仓库地址 |
-| ----------------------------------------------------- |
-|  https://github.com/GeneralLibrary/GeneralUpdate.Tools  |
+仓库地址：[https://github.com/GeneralLibrary/GeneralUpdate.Tools](https://github.com/GeneralLibrary/GeneralUpdate.Tools)
 
-| 功能 | 支持 | 说明 |
-| ------------------------------- | -------------- | ------------------------------------------------------------ |
-| 构建补丁包 | 是 | 比较前后版本，识别更新、新增或删除的文件 |
-| 构建版本配置 | 是 | 轻松生成版本配置文件 |
-| 扩展管理器 | 是 | 打包和管理应用程序扩展 |
+## 下载与运行
 
-![](imgs\tool.png)
+### 方式一：从源码运行（推荐开发者）
 
-![](imgs\tool2.png)
+当前工具基于 .NET 10 构建。确保本机安装了 [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)：
 
-![](imgs\tool3.png)
-
----
-
-## 功能说明
-
-### 1. 构建补丁包
-
-#### 功能介绍
-
-补丁包构建器用于创建差异更新包，通过对比旧版本和新版本，仅打包发生变化的文件，从而大幅减少更新包体积和下载时间。
-
-
-#### 参数说明
-
-| 名称 | 说明 |
-| ---------------- | ------------------------------------------------------------ |
-| 源路径 | 旧版本文件夹的路径 |
-| 目标路径 | 新版本文件夹的路径 |
-| 补丁路径 | 最终更新补丁包将生成的路径 |
-| 构建 | 递归比较源路径和目标路径文件夹中的所有项目文件（DLL、exe 等），通过二进制差异检查和增量检查分析需要更新的文件列表，然后根据文件夹结构打包更新文件 |
-| 清空 | 清除当前输入的内容 |
-
----
-
-### 2. 构建 OSS 版本配置
-
-#### 功能介绍
-
-OSS 版本配置构建器用于生成 `version.json` 配置文件，该文件包含更新包的元数据信息，告知客户端应用程序如何获取和验证更新包。
-
-
-#### 参数说明
-
-| 名称 | 说明 |
-| ---------------------- | ------------------------------------------------------------ |
-| 发布日期时间 | 更新包的发布时间 |
-| 包名 | 更新包的名称 |
-| 哈希值 | 更新包的哈希值（用于完整性验证） |
-| 版本号 | 更新包的版本号 |
-| 下载地址 | 更新包的下载 |
-| 获取哈希 | 获取更新包哈希值的功能 |
-| 追加 | 将新的更新信息追加到现有版本详情中 |
-| 清空 | 清除所有填写的内容 |
-| 复制 | 将生成的内容复制到剪贴板 |
-| 构建 | 将版本配置文件（.json）生成到本地磁盘 |
-
----
-
-### 3. 扩展管理器
-
-#### 功能介绍
-
-扩展管理器（ExtensionView）是 GeneralUpdate.Tools 的核心功能之一，用于将应用程序扩展打包成可分发的标准格式。该工具自动创建包含所有必要元数据的扩展包，支持平台特定配置、依赖管理和自定义属性，非常适合构建插件系统和扩展市场。
-
-
-#### 核心特性
-
-- **完整的元数据管理 **：支持扩展名称、版本、描述、发布者、许可证等标准字段
-- **平台支持 **：可指定目标平台（Windows / Linux / MacOS）
-- **版本兼容性 **：定义最小和最大主机版本要求
-- **依赖管理 **：声明扩展依赖的其他扩展
-- **自动打包 **：自动压缩扩展目录并生成 manifest.json
-- **自定义属性 **：支持添加额外的键值对元数据
-- **分类标签 **：通过类别标签组织和发现扩展
-
----
-
-## 扩展管理器使用指南
-
-### 基本信息字段
-
-#### 扩展名称
-
-**描述**：扩展的唯一标识符，建议使用小写字母和连字符，不含空格。
-
-
-**示例**：`my-awesome-plugin`、`data-exporter`
-
----
-
-#### 显示名称
-
-**描述**：面向用户的友好显示名称，将显示在扩展列表和详情页面中。
-
-
-**示例**：`My Awesome Plugin`、`Data Exporter Tool`
-
----
-
-#### 版本号
-
-**描述**：扩展的版本号，建议遵循语义化版本规范（SemVer），格式为 `主版本.次版本.修订号.构建号`。
-
-
-**示例**：`1.0.0.0`、`2.1.3.0`
-
----
-
-#### 描述
-
-**描述**：扩展功能的详细说明，告诉用户该扩展的用途和特性。支持多行文本。
-
-
-**示例**：
-```
-此扩展为您的应用程序添加强大的数据导出功能，
-支持多种格式，包括 CSV、Excel 和 JSON。
+```powershell
+git clone https://github.com/GeneralLibrary/GeneralUpdate.Tools.git
+cd GeneralUpdate.Tools\src
+dotnet run --project GeneralUpdate.Tools.csproj
 ```
 
----
+### 方式二：下载预编译版本
 
-#### 发布者
+前往 [GeneralUpdate.Tools Releases](https://github.com/GeneralLibrary/GeneralUpdate.Tools/releases) 下载对应平台的可执行文件，直接运行即可。
 
-**描述**：扩展的发布者名称或组织标识符。
+> Simulation 模块内部会调用 `dotnet publish` 构建测试应用，因此使用仿真功能时必须安装 .NET SDK，仅运行 Patch / Extension / OSS / Config 模块则不需要。
 
+## 六个模块速览
 
-**示例**：`YourCompany`、`john-doe`、`awesome-dev-team`
-
----
-
-#### 许可证
-
-**描述**：扩展使用的开源许可证标识符。
-
-
-**示例**：`MIT`、`Apache-2.0`、`GPL-3.0`、`BSD-3-Clause`
-
----
-
-#### 分类
-
-**描述**：扩展所属的分类标签，多个分类用逗号分隔。用于组织和搜索扩展。
-
-
-**示例**：`Tools, Productivity`、`Data, Export, Utilities`
-
-**常见分类 Common Categories**：
-- `Tools` - 工具类
-- `Productivity` - 效率提升
-- `Data` - 数据处理
-- `UI` - 用户界面
-- `Security` - 安全
-- `Development` - 开发
+| 模块 | 你提供 | 工具产出 | 下游消费者 |
+|------|--------|----------|------------|
+| **Patch** | 旧版本目录 + 新版本目录 | `{name}.zip`（含 `.patch` 文件、新文件、`generalupdate.delete.json`） | Server、OSS/CDN、Core Upgrade 进程 |
+| **Extension** | 扩展源目录 + 元数据 | `{name}_{version}.zip`（含 `manifest.json`） | `GeneralUpdate.Extension` 组件 |
+| **OSS Config** | 包名、版本、下载 URL、本地 ZIP（计算 Hash） | `oss_config.json`（版本数组） | OSS 客户端、对象存储发布流程 |
+| **Config** | Client/Upgrade 的 `.csproj` | `generalupdate.manifest.json` + `sample_output/` 发布目录 | Client/Upgrade 启动引导 |
+| **Simulation** | 旧版本目录 + 补丁 ZIP | 本地更新服务 + `simulation_report.md` | 发布前质量把关 |
+| **Hash** | 本地文件（ZIP） | SHA256 小写十六进制字符串 | 完整性校验、服务端版本记录 |
 
 ---
 
-### 路径配置
+## Patch：生成补丁包
 
-#### 扩展目录
+### 解决什么问题
 
-**描述**：包含扩展所有文件的源目录路径。该目录中的所有文件将被打包到最终的扩展包中。
+当你发布了一个新版本，用户不想下载整个安装包。Patch 模块比较旧版本目录和新版本目录，只输出变更内容：修改过的文件生成二进制差分 `.patch`，新增文件直接复制，删除的文件写入清单。差分包通常远小于完整发布目录。
 
+### 输入
 
-**操作 Operation**：点击 "Pick" 按钮选择文件夹
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| Old Directory | ✅ | 用户当前安装的旧版本发布目录，例如 `publish\v1.0.0` |
+| New Directory | ✅ | 准备发布的新版本目录，例如 `publish\v2.0.0` |
+| Package Name | ❌ | 输出 ZIP 文件名（不含 `.zip`），为空时自动生成 `patch_yyyyMMddHHmmss` |
+| Version | ✅ | 目标版本号，格式 `MAJOR.MINOR.PATCH`（如 `2.0.0`）或 `MAJOR.MINOR.PATCH-prerelease+build` |
+| Output Directory | ❌ | ZIP 输出目录，为空时输出到桌面 |
 
-**目录结构示例 Directory Structure**：
+### 工具内部做了什么
+
+1. 校验 old/new 目录存在、version 格式合法。
+2. 创建临时目录 `gupatch_yyyyMMddHHmmss`。
+3. 递归比较 old/new：**修改文件** → 生成 `.patch` 二进制差分；**新增文件** → 直接复制；**删除文件** → 记录 hash 到 `generalupdate.delete.json`。
+4. 将临时目录压缩为 `{PackageName}.zip`。
+5. 删除临时目录，ZIP 保留在 Output Directory。
+
+底层调用的是 `GeneralUpdate.Core.Pipeline.DiffPipeline.CleanAsync(oldDir, newDir, patchDir)`，和你的 CI 脚本走的是同一条代码路径。
+
+### 输出
+
 ```
-MyExtension/
-  ├── bin/
-  │   ├── MyExtension.dll
-  │   └── dependencies/
-  ├── resources/
-  │   ├── icons/
-  │   └── templates/
-  └── README.md
+{OutputDirectory}/{PackageName}.zip
+  ├── changed.dll.patch           ← 二进制差分
+  ├── new_file.dll                ← 新增文件（保持目录结构）
+  └── generalupdate.delete.json    ← 删除清单
 ```
 
----
+### 下游如何使用
 
-#### 导出路径
-
-**描述**：最终生成的扩展包（.zip 文件）的保存目录。
-
-
-**操作 Operation**：点击 "Pick" 按钮选择保存位置
-
-**输出格式 Output Format**：生成的文件名格式为 `{ExtensionName}_{Version}.zip`
-
-
-**示例**：`my-awesome-plugin_1.0.0.0.zip`
+- 把 ZIP 放到 Server 的 `wwwroot/packages/` 目录，更新 `versions.json` 中的 `Url` 和 `Hash`
+- 或上传到 OSS/CDN，把下载链接写入 `oss_config.json`
+- Core Upgrade 进程下载 ZIP 后，`DiffPipeline.DirtyAsync` 根据 `.patch` 和删除清单完成更新
 
 ---
 
-### 依赖关系
+## Extension：打包扩展
 
-#### 依赖项
+### 解决什么问题
 
-**描述**：该扩展所依赖的其他扩展的 ID 列表，多个依赖项用逗号分隔。扩展系统会自动处理依赖关系的解析和安装顺序。
+如果你使用 `GeneralUpdate.Extension` 组件管理插件/扩展，每次发布新扩展都需要手动构建标准格式的 ZIP 包并生成 `manifest.json`。Extension 模块把你从手工压缩和手写 JSON 中解放出来。
 
+### 输入
 
-**格式 Format**：逗号分隔的扩展 GUID 列表
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| Name | ✅ | 扩展唯一标识，建议小写+连字符，如 `my-data-exporter` |
+| Version | ✅ | 语义化版本，如 `1.0.0` |
+| Description | ❌ | 扩展功能描述 |
+| Publisher | ❌ | 发布者名称 |
+| License | ❌ | 许可证标识，如 `MIT` |
+| Extension Directory | ✅ | 扩展源文件目录，点击 Pick 选择文件夹 |
+| Export Directory | ❌ | 输出目录，为空时输出到桌面 |
+| Custom Properties | ❌ | 自定义键值对，写入 `manifest.json.customProperties` |
 
-**示例**：
+### 工具内部做了什么
+
+1. 校验目录存在、version 格式合法。
+2. 将 Extension Directory 中所有文件打包为 ZIP。
+3. 在 ZIP 根目录写入 `manifest.json`。
+
+### 输出
+
 ```
-550e8400-e29b-41d4-a716-446655440001,
-550e8400-e29b-41d4-a716-446655440002
-```
-
-**使用场景
-- 扩展需要其他扩展提供的功能
-- 共享公共库或资源
-- 确保正确的加载顺序
-
----
-
-### 版本兼容性
-
-#### 最小主机版本
-
-**描述**：扩展支持的最低主机应用程序版本。如果主机版本低于此值，扩展将被标记为不兼容。
-
-
-**格式 Format**：语义化版本号（不含构建号）Semantic version number (without build number)
-
-**示例**：`1.0.0`、`2.5.0`
-
----
-
-#### 最大主机版本
-
-**描述**：扩展支持的最高主机应用程序版本。如果主机版本高于此值，扩展将被标记为不兼容。
-
-
-**格式 Format**：语义化版本号（不含构建号）Semantic version number (without build number)
-
-**示例**：`3.0.0`、`2.9.9`
-
-**兼容性检查逻辑 Compatibility Check Logic**：
-```
-MinHostVersion ≤ 主机版本 ≤ MaxHostVersion
-MinHostVersion ≤ Host Version ≤ MaxHostVersion
-```
-
-**示例场景**：
-- 主机版本：`2.0.0`
-- 最小主机版本：`1.5.0`
-- 最大主机版本：`2.5.0`
-- 结果：✓ 兼容 Compatible
-
----
-
-### 平台和格式
-
-#### 格式
-
-**描述**：扩展包的文件格式。目前固定为 `.zip` 格式，这是一个只读字段。
-
-
-**值 Value**：`.zip` （只读 Read-only）
-
----
-
-#### 发布日期
-
-**描述**：扩展的发布日期。用于版本追踪和显示发布时间线。
-
-
-**操作 Operation**：使用日历选择器选择日期
-
----
-
-#### 平台
-
-**描述**：扩展支持的目标操作系统平台。选择正确的平台可以确保扩展仅在兼容的系统上安装和运行。
-
-
-**可选值 Available Options**：
-- `Windows` - 仅支持
-- `Linux` - 仅支持
-- `MacOS` - 仅支持
-
-**选择指南 Selection Guide**：
-- 如果扩展使用了平台特定的 API 或库，选择对应的平台
-- 跨平台扩展可以为每个平台创建单独的版本
-- 平台选择影响扩展在不同操作系统上的可见性和可安装性
-
----
-
-### 选项
-
-#### 预发布版本
-
-**描述**：标记该扩展版本是否为预发布版本（如 Alpha、Beta、RC）。预发布版本通常用于测试和早期访问。
-
-
-**复选框 Checkbox**：勾选表示预发布
-
-**使用场景
-- 内部测试版本
-- 公开测试版本
-- 候选发布版本
-
-**影响 Impact**：
-- 预发布版本可能在扩展市场中单独显示或标记 Pre-release versions may be displayed or marked separately in extension marketplaces
-- 用户可以选择是否接收预发布版本的自动更新
-
----
-
-### 自定义属性
-
-#### 启用自定义属性
-
-**描述**：启用此选项后，可以为扩展添加额外的键值对元数据，用于存储扩展特定的配置或信息。
-
-
-**复选框 Checkbox**：勾选以显示自定义属性输入区域
-
----
-
-#### 添加自定义属性
-
-**操作步骤 Operation Steps**：
-
-1. **输入属性键 Enter Property Key**：在 "Property" 字段中输入属性名称"Property" field
-   - 建议使用驼峰命名法或连字符
-   - 示例：`maxConnections`、`default-theme`、`apiEndpoint`
-
-2. **输入属性值 Enter Property Value**：在 "Value" 字段中输入对应的值"Value" field
-   - 支持字符串、数字等各种值
-   - 示例：`100`、`dark`、`https://api.example.com`
-
-3. **点击添加 Click Add**：点击 "Add" 按钮将属性添加到列表 Click the "Add" button to add the property to the list
-
-4. **管理属性 Manage Properties**：
-   - 查看已添加的属性
-   - 点击 "Remove" 删除不需要的属性 Click "Remove" to delete unwanted properties
-
-**使用场景
-- 存储扩展特定的配置选项 Store extension-specific configuration options
-- 记录扩展的元数据信息
-- 传递初始化参数
-- 存储扩展的 API 端点或资源路径 Store extension API endpoints or resource paths
-
-**示例**：
-```json
-{
-  "maxConcurrentTasks": "5",
-  "defaultLanguage": "en-US",
-  "apiBaseUrl": "https://api.myextension.com",
-  "enableDebugMode": "false"
-}
-```
-
----
-
-## 操作流程
-
-### 创建扩展包的完整步骤
-
-#### 步骤 1：准备扩展文件
-
-确保您的扩展目录包含所有必要的文件：
-- 程序集文件（DLL、可执行文件）
-- 资源文件（图标、模板、配置文件）
-- 依赖库
-- 文档文件（README、LICENSE）
-
----
-
-#### 步骤 2：打开扩展管理器
-
-1. 启动 GeneralUpdate.Tools Launch GeneralUpdate.Tools
-2. 点击顶部的 "Extension" 选项卡 Click the "Extension" tab at the top
-3. 进入扩展管理器界面---
-
-#### 步骤 3：填写基本信息
-
-按照上述字段说明，依次填写：
-- Extension Name（扩展名称）
-- Display Name（显示名称）
-- 版本号
-- 描述
-- 发布者
-- 许可证
-- Categories（分类）
-
-- 扩展名称
-- 显示名称
-- 版本
-- 描述
-- 发布者
-- 许可证
-- 分类
-
----
-
-#### 步骤 4：配置路径
-
-1. **选择扩展目录**：
-   - 点击 "Extension Directory" 旁的 "Pick" 按钮
-   - 浏览并选择包含扩展文件的文件夹
-
-2. **选择导出路径**：
-   - 点击 "Export Path" 旁的 "Pick" 按钮
-   - 选择保存生成的扩展包的目录
-
----
-
-#### 步骤 5：配置依赖和兼容性（可选）
-
-1. **添加依赖项
-   - 在 "Dependencies" 字段中输入依赖扩展的 GUID Enter the GUID of dependent extensions in the "Dependencies" field
-   - 多个依赖项用逗号分隔
-
-2. **设置版本兼容性 Set Version Compatibility**：
-   - 填写 "Min Host Version" Fill in "Min Host Version"
-   - 填写 "Max Host Version" Fill in "Max Host Version"
-
----
-
-#### 步骤 6：选择平台和选项
-
-1. **选择目标平台**：
-   - 从 "Platform" 下拉列表中选择 Windows、Linux 或 MacOS Select Windows, Linux, or MacOS from the "Platform" dropdown list
-
-2. **设置发布日期 Set Release Date**：
-   - 使用日历选择器选择发布日期
-
-3. **标记预发布版本 Mark Pre-release Version**（如果适用 if applicable）：
-   - 勾选 "Pre-release" 复选框 Check the "Pre-release" checkbox
-
----
-
-#### 步骤 7：添加自定义属性（可选）
-
-2. 在输入框中添加键值对
-3. 点击 "Add" 按钮添加每个属性 Click the "Add" button to add each property
-4. 根据需要添加多个自定义属性
-
----
-
-#### 步骤 8：生成扩展包
-
-1. **检查所有信息 Review All Information**：
-   - 确保所有必填字段都已正确填写
-   - 验证路径是否正确
-
-2. **点击 Build 按钮 Click Build Button**：
-   - 点击底部的 "Build" 按钮
-   - 等待打包过程完成
-
-3. **验证成功
-   - 将显示成功消息，包含文件名和位置 A success message will be displayed with the file name and location
-   - 生成的扩展包位于导出路径中
-
----
-
-#### 步骤 9：验证扩展包
-
-生成后，验证扩展包是否包含：
-1. 所有源文件（从扩展目录压缩）
-2. `manifest.json` 文件（自动生成）
-
-可以使用解压缩工具打开 .zip 文件进行检查：
-```
-MyExtension_1.0.0.0.zip
-  ├── manifest.json          ← 扩展元数据 Extension metadata
+{ExportDirectory}/{Name}_{Version}.zip
+  ├── manifest.json               ← 扩展元数据
   ├── bin/
   │   └── MyExtension.dll
   ├── resources/
-  └── README.md
-```
-
----
-
-### 清除表单
-
-如果需要重新开始或清除所有输入的内容：
-1. 点击底部的 "Clear" 按钮 Click the "Clear" button at the bottom
-2. 所有字段将重置为默认值 All fields will be reset to default values
-3. 自定义属性列表将被清空 Custom properties list will be cleared
-
-
----
-
-## 输出结果
-
-### 生成的扩展包结构
-
-扩展管理器生成的 .zip 文件具有以下结构：
-
-
-```
-ExtensionName_Version.zip
-  ├── manifest.json                    ← 扩展元数据 Extension metadata
-  ├── [所有源目录中的文件和文件夹]     ← All files and folders from source directory
   └── ...
 ```
 
----
-
-### manifest.json 文件内容
-
-`manifest.json` 文件包含所有扩展元数据，示例结构：
-
+`manifest.json` 示例：
 
 ```json
 {
-  "Name": "my-awesome-plugin",
-  "DisplayName": "My Awesome Plugin",
-  "Version": "1.0.0.0",
-  "Description": "This extension adds powerful features to your application",
-  "Publisher": "YourCompany",
-  "License": "MIT",
-  "Categories": ["Tools", "Productivity"],
-  "Dependencies": "550e8400-e29b-41d4-a716-446655440001",
-  "MinHostVersion": "1.0.0",
-  "MaxHostVersion": "2.0.0",
-  "Format": ".zip",
-  "ReleaseDate": "2026-02-12T00:00:00",
-  "IsPreRelease": false,
-  "Platform": {
-    "DisplayName": "Windows",
-    "Value": 1
-  },
-  "FileSize": 1048576,
-  "CustomProperties": {
-    "maxConnections": "100",
-    "apiEndpoint": "https://api.example.com"
-  }
+  "name": "my-data-exporter",
+  "version": "1.0.0",
+  "description": "Export data to CSV/Excel/JSON",
+  "publisher": "MyCompany",
+  "license": "MIT",
+  "dependencies": "",
+  "minHostVersion": "",
+  "maxHostVersion": "",
+  "isPreRelease": false,
+  "platform": { "displayName": "Windows", "value": 1 },
+  "format": ".zip",
+  "releaseDate": "2026-06-01T00:00:00",
+  "customProperties": { "maxConnections": "100" }
 }
 ```
 
----
+### 下游如何使用
 
-### 字段映射说明
-
-| 界面字段 | JSON 字段 | 数据类型 | 说明 |
-| ----------------------- | -------------------- | ------------------ | ---------------------------------------- |
-|  Extension Name           |  Name                  |  string              | 扩展唯一标识符 |
-|  Display Name             |  DisplayName           |  string              | 显示名称 |
-|  Version                  |  Version               |  string              | 版本号 |
-|  Description              |  Description           |  string              | 扩展描述 |
-|  Publisher                |  Publisher             |  string              | 发布者 |
-|  License                  |  License               |  string              | 许可证 |
-|  Categories               |  Categories            |  array               | 分类列表 |
-|  Dependencies             |  Dependencies          |  string              | 依赖项（逗号分隔）Dependencies (comma-separated) |
-|  Min Host Version         |  MinHostVersion        |  string              | 最小主机版本 |
-|  Max Host Version         |  MaxHostVersion        |  string              | 最大主机版本 |
-|  Format                   |  Format                |  string              | 文件格式 |
-|  Release Date             |  ReleaseDate           |  DateTime            | 发布日期 |
-|  Pre-release              |  IsPreRelease          |  boolean             | 是否预发布 |
-|  Platform                 |  Platform              |  object              | 平台信息 |
-|  Custom Properties        |  CustomProperties      |  object              | 自定义属性字典 |
+- Extension Host 调用 `ExtensionManager.QueryRemoteExtensionsAsync(...)` 获取扩展列表
+- 安装时下载 ZIP，读取 `manifest.json` 进行兼容性检查和依赖解析
+- 详见 [GeneralUpdate.Extension](./GeneralUpdate.Extension.md)
 
 ---
 
-## 最佳实践
+## OSS Config：生成 OSS 版本清单
 
-### 命名规范
+### 解决什么问题
 
-1. **扩展名称 Extension Name**：
-   - 使用小写字母和连字符
-   - 避免空格和特殊字符
-   - 保持简洁且具有描述性
-   - ✓ 正确 Correct：`data-exporter`、`theme-customizer`
-   - ✗ 错误 Incorrect：`Data Exporter`、`Theme@Customizer`
+如果你使用 OSS 模式更新（静态文件服务器），你需要维护一个 `versions.json` 或 `oss_config.json`，让客户端知道有哪些版本可以下载。OSS Config 模块帮你整理版本信息并计算 SHA256。
 
-2. **版本号 Version Number**：
-   - 遵循语义化版本规范 Follow Semantic Versioning
-   - 格式：`主版本.次版本.修订号.构建号` Format: `Major.Minor.Patch.Build`
-   - 示例：`1.0.0.0`、`2.1.3.5`
+### 输入
 
----
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| PacketName | ✅ | 更新包名称 |
+| Version | ✅ | 语义化版本号 |
+| Url | ✅ | 客户端可下载补丁包的完整地址 |
+| SHA256 | 推荐 | 选择本地 ZIP 文件后点击 ComputeHash 自动计算 |
 
-### 目录组织
+### 操作流程
 
-保持扩展目录结构清晰：
+1. 填写 PacketName、Version、Url。
+2. 点击 **ComputeHash**，选择本地补丁 ZIP 文件，自动填入 SHA256。
+3. 点击 **Add To List**，加入列表。
+4. 重复以上步骤添加所有版本。
+5. 点击 **Export**，生成 `oss_config.json`。
 
-Maintain a clear extension directory structure:
+### 输出
 
-```
-MyExtension/
-  ├── bin/                    ← 二进制文件 Binary files
-  │   ├── MyExtension.dll
-  │   └── dependencies/
-  ├── resources/              ← 资源文件 Resource files
-  │   ├── icons/
-  │   ├── templates/
-  │   └── localization/
-  ├── docs/                   ← 文档 Documentation
-  │   └── README.md
-  └── LICENSE                 ← 许可证 License
+```json
+[
+  {
+    "PacketName": "client_1.0.0_to_2.0.0",
+    "Hash": "f2c7a8b3...",
+    "Version": "2.0.0",
+    "Url": "https://cdn.example.com/client_1.0.0_to_2.0.0.zip",
+    "ReleaseDate": ""
+  }
+]
 ```
 
----
+### 下游如何使用
 
-### 版本兼容性管理
-
-1. **设置合理的版本范围 Set Reasonable Version Range**：
-   - 不要设置过窄的版本范围 Don't set too narrow version range
-   - 考虑向后兼容性
-   - 示例：Min `1.0.0`、Max `2.0.0` (支持 1.x 所有版本)
-
-2. **主版本更新 Major Version Updates**：
-   - 主机应用程序发生重大变化时，更新 Min/Max Host Version
-   - 为新的主版本创建新的扩展版本
+- 将 `oss_config.json` 上传到 OSS bucket 或静态文件服务器
+- OSS 客户端读取此文件发现可用版本，下载后校验 Hash
+- 详见 [GeneralClient.OSS](./GeneralClient.OSS.md)
 
 ---
 
-### 依赖管理
+## Config：生成启动清单
 
-1. **最小化依赖 Minimize Dependencies**：
-   - 只声明必需的依赖项
-   - 避免循环依赖
+### 解决什么问题
 
-2. **文档化依赖 Document Dependencies**：
-   - 在描述中说明为什么需要这些依赖
-   - 提供依赖项的获取方式
+Client 和 Upgrade 启动时需要知道主程序名、升级程序名、版本号、ProductId、UpdatePath 等信息。Config 模块从 `.csproj` 中自动提取 AssemblyName 和 TargetFramework，帮你生成 `generalupdate.manifest.json`，省去手写和手误。
 
----
+### 输入
 
-### 自定义属性使用
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| Client .csproj | ✅ | 主程序的 `.csproj` 文件路径 |
+| Upgrade .csproj | ❌ | 升级程序的 `.csproj` 路径 |
+| ClientVersion | ✅ | 客户端当前版本，如 `1.0.0` |
+| UpgradeClientVersion | ✅ | 升级程序版本，如 `1.0.0` |
+| AppType | ✅ | Client / Upgrade / OssClient / OssUpgrade |
+| ProductId | ✅ | 产品标识 GUID |
+| UpdatePath | ✅ | 升级程序相对主程序的子目录，如 `update/` |
 
-1. **使用场景
-   - 存储扩展特定的配置 Store extension-specific configurations
-   - 记录扩展的技术要求
-   - 传递初始化参数
+### 操作流程
 
-2. **命名建议 Naming Recommendations**：
-   - 使用驼峰命名法 Use camelCase
-   - 保持键名简洁明了
-   - 添加前缀避免冲突
+1. 点击 Browse 选择 Client `.csproj`（必填）和 Upgrade `.csproj`（可选）。
+2. 点击 **Analyze**，工具自动读取 AssemblyName 填入 `MainAppName`、`UpdateAppName`。
+3. 手动填写 Version、AppType、ProductId、UpdatePath。
+4. 点击 **Generate**，在工具运行目录生成 `generalupdate.manifest.json`。
+5. 点击 **Generate Sample**，额外执行 `dotnet publish` 并输出可运行的发布目录。
 
----
+### 输出
 
-### 测试和验证
+`generalupdate.manifest.json`：
 
-1. **打包前检查 Pre-packaging Checks**：
-   - ✓ 验证所有文件是否完整
-   - ✓ 检查版本号是否正确
-   - ✓ 确认依赖项是否准确
-   - ✓ 测试扩展在目标平台上的运行
+```json
+{
+  "mainAppName": "ClientSample.exe",
+  "clientVersion": "1.0.0",
+  "appType": "Client",
+  "updateAppName": "UpgradeSample.exe",
+  "upgradeClientVersion": "1.0.0",
+  "productId": "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
+  "updatePath": "update/"
+}
+```
 
-2. **打包后验证 Post-packaging Verification**：
-   - ✓ 解压查看文件结构
-   - ✓ 检查 manifest.json 内容 Check manifest.json content
-   - ✓ 验证文件大小是否合理
-   - ✓ 在目标环境中安装测试
----
+Generate Sample 额外输出：
 
-### 发布管理
+```
+{工具运行目录}/sample_output/
+  ├── ClientSample.exe             ← Client dotnet publish 输出
+  ├── generalupdate.manifest.json
+  └── update/
+      └── UpgradeSample.exe        ← Upgrade dotnet publish 输出
+```
 
-1. **预发布版本 Pre-release Versions**：
-   - 使用预发布标记进行内部测试 Use pre-release flag for internal testing
-   - 收集反馈后再发布正式版本
+### 下游如何使用
 
-2. **版本更新 Version Updates**：
-   - 保持版本历史记录
-   - 在描述中记录更新日志
-   - 提供从旧版本升级的指导
-
----
-
-## 故障排除
-
-### 常见问题
-
-#### 问题 1：构建失败
-
-**可能原因 Possible Causes**：
-- 扩展目录不存在或无法访问
-- 导出路径无写入权限
-- 磁盘空间不足
-- 扩展目录为空
-
-**解决方案 Solutions**：
-1. 验证扩展目录路径是否正确
-2. 检查导出路径的写入权限
-3. 确保有足够的磁盘空间
-4. 确认扩展目录包含文件
+- Client 启动时读取 `generalupdate.manifest.json`，配合服务端地址和 AppSecretKey 即可进入更新流程
+- 不需要手写 `Configinfo`，只需用 `GeneralUpdateBootstrap` 读取 manifest
 
 ---
 
-#### 问题 2：验证错误
+## Simulation：本地更新仿真
 
-**可能原因 Possible Causes**：
-- 必填字段未填写
-- 版本号格式不正确
-- 路径格式无效
+### 解决什么问题
 
-**解决方案 Solutions**：
-1. 检查所有必填字段（名称、版本、目录、导出路径）Check all required fields (name, version, directory, export path)
-2. 使用正确的版本号格式（如 `1.0.0.0`）Use correct version number format (e.g., `1.0.0.0`)
-3. 确保路径使用正确的格式
+你刚用 Patch 模块生成了补丁包，但不确定这个包在实际更新流程中能不能跑通。Simulation 模块在你本机启动一个临时更新服务，构建 Client/Upgrade 样例，模拟一次完整的“发现版本 → 下载补丁 → 应用更新”闭环，最后输出 PASS/FAIL 报告。
 
----
+### 前置条件
 
-#### 问题 3：生成的包无法解压
+- 已安装 .NET 10 SDK（或更高版本）
+- `dotnet --version` 可正常执行
+- 本地 5000 端口未被占用（可配置）
 
-**可能原因 Possible Causes**：
-- 打包过程被中断
-- 磁盘空间在打包过程中耗尽
-- 源文件被锁定或正在使用
+### 输入
 
-**解决方案 Solutions**：
-1. 重新生成扩展包
-2. 确保有足够的磁盘空间
-3. 关闭正在使用扩展文件的程序
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| Old App Directory | ✅ | 模拟用户当前安装的旧版本目录 |
+| Patch File | ✅ | Patch 模块生成的补丁 ZIP |
+| CurrentVersion | ✅ | 旧版本号（Simulation 内部传给 Client，用于版本校验） |
+| TargetVersion | ✅ | 新版本号（Simulation 内部赋值到补丁 ZIP，写入服务端版本源） |
+| AppType | ✅ | ClientApp = 1 / UpgradeApp = 2 |
+| Platform | ✅ | Windows = 1 / Linux = 2 |
+| AppSecretKey | ✅ | 客户端验证密钥 |
+| ProductId | ✅ | 产品标识 GUID |
+| UpdatePath | ✅ | 升级程序子目录名称，如 `update/` |
+| ServerPort | ❌ | 本地服务端口，默认 5000 |
 
----
+### 仿真过程
 
-#### 问题 4：自定义属性无法添加
+1. **校验**：旧目录存在、Patch ZIP 存在、version 格式合法、.NET SDK 可用。
+2. **发布 Client**：`dotnet publish test_app/Client/ClientSample.csproj` 到 App Directory。
+3. **发布 Upgrade**：`dotnet publish test_app/Upgrade/UpgradeSample.csproj` 到 `UpdatePath` 子目录。
+4. **生成 manifest**：在 App Directory 写入 `generalupdate.manifest.json`。
+5. **准备补丁**：把 Patch ZIP 复制到内部 `.server` 目录，计算 SHA256，写入服务端版本源。
+6. **启动服务**：本地服务监听 `http://localhost:{ServerPort}`，提供 `POST /Upgrade/Verification`、`POST /Upgrade/Report`、`GET /patch/{filename}`。
+7. **运行 Client**：启动 `ClientSample.exe`，传入 `--server-url http://localhost:5000 --app-secret ... --client-version 1.0.0`。
+8. **停止服务**：Client 完成更新或超时后停止服务。
+9. **生成报告**：检查目录文件变化，输出 `simulation_report.md`。
 
-**可能原因 Possible Causes**：
-- 属性键或值为空
-- 属性键已存在
+### 输出
 
-**解决方案 Solutions**：
-1. 确保键和值都已填写
-2. 使用唯一的属性键名
-3. 如需修改现有属性，先删除再重新添加 To modify existing properties, delete and re-add
+```
+{AppDirectory}/simulation_report.md    ← 仿真报告（PASS/FAIL + 时间线）
+```
 
----
-
-## 相关文档
-
-### GeneralUpdate 生态系统
-
-- **[GeneralUpdate.Core](./GeneralUpdate.Core.md)** - 核心更新组件
-- **[GeneralUpdate.Extension](./GeneralUpdate.Extension.md)** - 扩展管理系统
-- **[GeneralUpdate.ClientCore](./GeneralUpdate.ClientCore.md)** - 客户端更新组件
-- **[快速入门指南](../quickstart/Quik%20start.md)** - GeneralUpdate 快速入门 GeneralUpdate quick start
-
-### 外部资源
-
-- **[GeneralUpdate.Tools 源代码](https://github.com/GeneralLibrary/GeneralUpdate.Tools)** - GitHub 仓库 GitHub 仓库
-- **[GeneralUpdate 主项目](https://github.com/GeneralLibrary/GeneralUpdate)** - 主框架项目
-- **[问题反馈](https://github.com/GeneralLibrary/GeneralUpdate.Tools/issues)** - 报告问题和建议
+报告包含配置表、PASS/FAIL 结论、Notes 和完整时间线，可以直接贴到发布记录或 CI artifact。
 
 ---
 
-## 适用于
+## Hash：SHA256 校验
 
-| 产品 | 版本 |
-| ----------------- | ------------------------------------- |
-|  .NET               |  5, 6, 7, 8, 9, 10                      |
-|  .NET Framework     |  4.6.1+                                 |
-|  .NET Standard      |  2.0                                    |
-|  .NET Core          |  2.0+                                   |
-|  Windows            |  10+                                    |
-|  Linux              |  Ubuntu 20.04+, Debian 10+, Fedora 35+  |
-|  macOS              |  10.15+ (Catalina and later)            |
+### 解决什么问题
+
+补丁包上传到 CDN/OSS 后，必须确保客户端下载到的文件和原始包一致。Hash 功能对本地文件计算 SHA256，输出小写十六进制字符串，你应该把这个值写入版本清单或服务端返回数据。
+
+### 使用方式
+
+在 **OSS Config** 模块中，点击 **ComputeHash**，选择本地 ZIP 文件，自动填入 SHA256 字段。你也可以单独使用这个功能来校验任何文件。
+
+---
+
+## 推荐发布工作流
+
+这个顺序把六个模块串联成一个完整的发布流水线：
+
+```
+┌─────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐
+│ 发布新旧  │ -> │ Patch    │ -> │ OSS/Hash │ -> │ Config   │ -> │ Simulation│
+│ 版本目录  │    │ 生成补丁  │    │ 算 Hash   │    │ 生成清单  │    │ 本地验证  │
+└─────────┘    └──────────┘    └──────────┘    └──────────┘    └──────────┘
+```
+
+1. **构建发布目录**：在 CI 或本地 `dotnet publish` 得到 old/new 两个目录。
+2. **Patch**：选择 old/new，生成补丁 ZIP。
+3. **OSS Config**：对补丁 ZIP 计算 SHA256，填写下载 URL，导出 `oss_config.json`。（如果使用自建 Server，将相同信息写入 `versions.json`）。
+4. **Config**：选择 Client/Upgrade 的 `.csproj`，生成 `generalupdate.manifest.json`。
+5. **Simulation**：选择旧版本目录和补丁 ZIP，确认 PASS。
+6. **发布上线**：上传补丁 ZIP、OSS 清单到生产环境。
+
+---
+
+## 常见问题
+
+| 现象 | 原因与处理 |
+|------|-----------|
+| Version invalid | 使用 `1.0.0`、`2.0.0-beta.1` 格式。不要用 `1.0` 或 `v1.0.0` |
+| Patch 输出为空或极小 | old/new 目录可能选反，或两个目录内容完全一致。确认 old 是用户已安装版本，new 是目标版本 |
+| 找不到 `delete_files.json` | 当前文件名是 `generalupdate.delete.json`，位于 Patch ZIP 根目录 |
+| Simulation 提示找不到 SDK | 安装 .NET 10 SDK 并确保命令行可执行 `dotnet --version` |
+| Simulation 端口冲突 | 修改 `ServerPort` 或释放本地 5000 端口 |
+| 客户端下载后 Hash 校验失败 | 对**最终上传到 CDN/OSS 的文件**重新计算 Hash，检查是否被中间代理重压缩 |
+| Upgrade 进程没有启动 | 检查 `generalupdate.manifest.json` 中 `updateAppName` 和 `updatePath` 是否与发布目录结构一致 |
+
+---
+
+## 关联文档
+
+- [GeneralUpdate.Core](./GeneralUpdate.Core.md)：Client/Upgrade 更新主流程
+- [GeneralUpdate.Differential](./GeneralUpdate.Differential.md)：差分算法 Clean/Dirty 模式
+- [GeneralUpdate.Extension](./GeneralUpdate.Extension.md)：扩展包安装与版本管理
+- [GeneralClient.OSS](./GeneralClient.OSS.md)：OSS 更新链路
+- [入门实战手册](../quickstart/Beginner cookbook.md)：从零跑通完整更新闭环
+- [高级实战手册](../quickstart/Advanced cookbook.md)：CI/CD 集成与生产发布


### PR DESCRIPTION
Fixes issues in #61.

## Issues fixed

### 1. Incorrect Bowl description
The original PR described Bowl as "可靠下载与断点续传" (reliable download and resume). **Bowl monitors process crashes and performs backup recovery** — it has nothing to do with download resume. Removed entirely.

### 2. Irrelevant Bowl link
GeneralUpdate.Tools and Bowl have no relationship. The Bowl link has been removed from the related docs section.

### 3. Too vague — now specific and actionable
Every module now answers for the developer:
- **Where to download**: source clone + dotnet run, or pre-built from Releases
- **What you provide** (inputs): exact field tables with required/optional, format, examples
- **What you get** (outputs): exact file names, directory structures, JSON schemas
- **What the tool does internally**: step-by-step pipeline for each module
- **How downstream consumes it**: explicit connection to Server/OSS/Core/Extension
- **Recommended workflow**: diagram showing the 6-module chain

## Structure

| Section | Content |
|---------|---------|
| Download & Run | Two options (source, pre-built), SDK requirements |
| Six modules overview | Input → Output → Consumer table |
| Patch | Problem, inputs, internal pipeline, output structure, downstream |
| Extension | Problem, inputs, output + manifest.json example, downstream |
| OSS Config | Problem, inputs, workflow steps, output JSON, downstream |
| Config | Problem, inputs, workflow, manifest + sample_output |
| Simulation | Problem, prerequisites, inputs, 9-step process, report |
| Hash | Problem, usage |
| Release workflow | 6-step diagram connecting all modules |
| FAQ | 7 common issues with causes and fixes |
| Related docs | Core, Differential, Extension, OSS, cookbooks — no Bowl |

## Validation
- `npm run build -- --no-minify` passes
- Bowl reference count: 0
- All code paths verified against GeneralUpdate.Tools source