### PR TITLE
docs: update API references from UpdateAuth to HttpAuth

### DIFF
--- a/website/docs/doc/GeneralUpdate.Core.md
+++ b/website/docs/doc/GeneralUpdate.Core.md
@@ -771,7 +771,7 @@ await new GeneralUpdateBootstrap()
 | `Hooks<T>()` | `IUpdateHooks` | 更新生命周期前后置逻辑。 |
 | `UpdateReporter<T>()` | `IUpdateReporter` | 更新状态上报。 |
 | `SslPolicy<T>()` | `ISslValidationPolicy` | HTTPS 证书校验。 |
-| `UpdateAuth<T>()` | `IHttpAuthProvider` | HTTP 请求认证。 |
+| `HttpAuth<T>()` | `IHttpAuthProvider` | HTTP 请求认证。 |
 | `DownloadSource<T>()` | `IDownloadSource` | 版本清单和下载资源来源。 |
 | `DownloadPolicy<T>()` | `IDownloadPolicy` | 下载重试、超时、熔断等策略。 |
 | `DownloadExecutor<T>()` | `IDownloadExecutor` | 单文件下载实现。 |
@@ -929,11 +929,11 @@ public sealed class StaticBearerAuthProvider : IHttpAuthProvider
 
 await new GeneralUpdateBootstrap()
     .SetConfig(request)
-    .UpdateAuth<StaticBearerAuthProvider>()
+    .HttpAuth<StaticBearerAuthProvider>()
     .LaunchAsync();
 ```
 
-Core 内置的认证类型包括 `NoOpAuthProvider`、`BearerTokenAuthProvider`、`ApiKeyAuthProvider` 和 `HmacAuthProvider`。这些类型中部分构造函数需要参数，因此如果要通过 `UpdateAuth<T>()` 注册，通常需要写一个无参包装类。
+Core 内置的认证类型包括 `NoOpAuthProvider`、`BearerTokenAuthProvider`、`ApiKeyAuthProvider` 和 `HmacAuthProvider`。这些类型中部分构造函数需要参数，因此如果要通过 `HttpAuth<T>()` 注册，通常需要写一个无参包装类。
 
 ## HTTPS 证书策略：ISslValidationPolicy
 

--- a/website/docs/guide/Architecture.md
+++ b/website/docs/guide/Architecture.md
@@ -310,7 +310,7 @@ await new GeneralClientBootstrap()
     // 自定义下载重试策略
     .DownloadPolicy<CustomRetryPolicy>()
     // 自定义认证提供者
-    .UpdateAuth<BearerTokenAuthProvider>()
+    .HttpAuth<BearerTokenAuthProvider>()
     // 生命周期钩子
     .Hooks<CustomUpdateHooks>()
     .SetConfig(config)

--- a/website/docs/guide/Security.md
+++ b/website/docs/guide/Security.md
@@ -121,7 +121,7 @@ var config = new Configinfo
 
 // 或者通过 AbstractBootstrap 注入
 await new GeneralClientBootstrap()
-    .UpdateAuth<BearerTokenAuthProvider>()
+    .HttpAuth<BearerTokenAuthProvider>()
     .SetConfig(config)
     .LaunchAsync();
 ```

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/doc/GeneralUpdate.Core.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/doc/GeneralUpdate.Core.md
@@ -770,7 +770,7 @@ All extension registration methods are provided by `AbstractBootstrap` and can b
 | `Hooks<T>()` | `IUpdateHooks` | Lifecycle callbacks. |
 | `UpdateReporter<T>()` | `IUpdateReporter` | Update status reporting. |
 | `SslPolicy<T>()` | `ISslValidationPolicy` | HTTPS certificate validation. |
-| `UpdateAuth<T>()` | `IHttpAuthProvider` | HTTP request authentication. |
+| `HttpAuth<T>()` | `IHttpAuthProvider` | HTTP request authentication. |
 | `DownloadSource<T>()` | `IDownloadSource` | Version manifest and asset source. |
 | `DownloadPolicy<T>()` | `IDownloadPolicy` | Retry, timeout, circuit breaker. |
 | `DownloadExecutor<T>()` | `IDownloadExecutor` | Single-file download implementation. |
@@ -926,11 +926,11 @@ public sealed class StaticBearerAuthProvider : IHttpAuthProvider
 
 await new GeneralUpdateBootstrap()
     .SetConfig(request)
-    .UpdateAuth<StaticBearerAuthProvider>()
+    .HttpAuth<StaticBearerAuthProvider>()
     .LaunchAsync();
 ```
 
-Core includes `NoOpAuthProvider`, `BearerTokenAuthProvider`, `ApiKeyAuthProvider`, and `HmacAuthProvider`. Some require constructor parameters, so create a parameterless wrapper when registering through `UpdateAuth<T>()`.
+Core includes `NoOpAuthProvider`, `BearerTokenAuthProvider`, `ApiKeyAuthProvider`, and `HmacAuthProvider`. Some require constructor parameters, so create a parameterless wrapper when registering through `HttpAuth<T>()`.
 
 ## HTTPS certificate policy: ISslValidationPolicy
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guide/Architecture.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guide/Architecture.md
@@ -212,7 +212,7 @@ GeneralUpdate provides rich extensibility through `AbstractBootstrap`'s CRTP pat
 await new GeneralClientBootstrap()
     .SslPolicy<CustomSslPolicy>()
     .DownloadPolicy<CustomRetryPolicy>()
-    .UpdateAuth<BearerTokenAuthProvider>()
+    .HttpAuth<BearerTokenAuthProvider>()
     .Hooks<CustomUpdateHooks>()
     .SetConfig(config)
     .LaunchAsync();

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/doc/GeneralUpdate.Core.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/doc/GeneralUpdate.Core.md
@@ -771,7 +771,7 @@ await new GeneralUpdateBootstrap()
 | `Hooks<T>()` | `IUpdateHooks` | 更新生命周期前后置逻辑。 |
 | `UpdateReporter<T>()` | `IUpdateReporter` | 更新状态上报。 |
 | `SslPolicy<T>()` | `ISslValidationPolicy` | HTTPS 证书校验。 |
-| `UpdateAuth<T>()` | `IHttpAuthProvider` | HTTP 请求认证。 |
+| `HttpAuth<T>()` | `IHttpAuthProvider` | HTTP 请求认证。 |
 | `DownloadSource<T>()` | `IDownloadSource` | 版本清单和下载资源来源。 |
 | `DownloadPolicy<T>()` | `IDownloadPolicy` | 下载重试、超时、熔断等策略。 |
 | `DownloadExecutor<T>()` | `IDownloadExecutor` | 单文件下载实现。 |
@@ -929,11 +929,11 @@ public sealed class StaticBearerAuthProvider : IHttpAuthProvider
 
 await new GeneralUpdateBootstrap()
     .SetConfig(request)
-    .UpdateAuth<StaticBearerAuthProvider>()
+    .HttpAuth<StaticBearerAuthProvider>()
     .LaunchAsync();
 ```
 
-Core 内置的认证类型包括 `NoOpAuthProvider`、`BearerTokenAuthProvider`、`ApiKeyAuthProvider` 和 `HmacAuthProvider`。这些类型中部分构造函数需要参数，因此如果要通过 `UpdateAuth<T>()` 注册，通常需要写一个无参包装类。
+Core 内置的认证类型包括 `NoOpAuthProvider`、`BearerTokenAuthProvider`、`ApiKeyAuthProvider` 和 `HmacAuthProvider`。这些类型中部分构造函数需要参数，因此如果要通过 `HttpAuth<T>()` 注册，通常需要写一个无参包装类。
 
 ## HTTPS 证书策略：ISslValidationPolicy
 


### PR DESCRIPTION
Reflects rename of UpdateAuth to HttpAuth in GeneralUpdate Core library.

See: GeneralLibrary/GeneralUpdate#495