### PR TITLE
docs: rewrite Beginner cookbook with step-by-step self-guided flow

### DIFF
--- a/website/docs/quickstart/Beginner cookbook.md
+++ b/website/docs/quickstart/Beginner cookbook.md
@@ -3,17 +3,17 @@ sidebar_position: 3
 title: 入门实战手册
 ---
 
-import ReactPlayer from 'react-player'
-
 # GeneralUpdate 入门实战手册
 
 这篇手册面向第一次接触 GeneralUpdate 的开发者。目标不是一次讲完所有 API，而是让你从零开始，写完 Client → 写完 Upgrade → 用 Tools 生成配置 → 启动 Server → 一条命令跑通完整的"发现更新 → 下载 → 应用 → 回到新版本"闭环。
 
-<ReactPlayer
-  url='https://www.bilibili.com/video/BV12P9dBiEEh'
-  controls
-  width='100%'
-  style={{ borderRadius: '8px' }}
+<iframe
+  src="//player.bilibili.com/player.html?bvid=BV12P9dBiEEh&page=1"
+  width="100%"
+  height="480"
+  style={{ borderRadius: '8px', border: 'none' }}
+  allowFullScreen
+  scrolling="no"
 />
 
 ## 更新流程总览

--- a/website/docs/quickstart/Beginner cookbook.md
+++ b/website/docs/quickstart/Beginner cookbook.md
@@ -3,257 +3,378 @@ sidebar_position: 3
 title: 入门实战手册
 ---
 
+import ReactPlayer from 'react-player'
+
 # GeneralUpdate 入门实战手册
 
-这篇手册面向第一次接触 GeneralUpdate 的开发者。目标不是一次讲完所有 API，而是让你先跑通一次"发现更新 → 下载补丁 → 启动升级 → 应用补丁 → 回到新版本"的闭环，然后知道每个组件在流程里负责什么。
+这篇手册面向第一次接触 GeneralUpdate 的开发者。目标不是一次讲完所有 API，而是让你从零开始，写完 Client → 写完 Upgrade → 用 Tools 生成配置 → 启动 Server → 一条命令跑通完整的"发现更新 → 下载 → 应用 → 回到新版本"闭环。
 
-## 你会用到哪些角色
+<ReactPlayer
+  url='https://www.bilibili.com/video/BV12P9dBiEEh'
+  controls
+  width='100%'
+  style={{ borderRadius: '8px' }}
+/>
 
-| 角色 | 在样例中的位置 | 负责什么 | 深入阅读 |
-| --- | --- | --- | --- |
-| Hub | `src\Hub` | 交互式示例浏览器，通过菜单选择并运行各类更新场景 | [GeneralUpdate.Core](../doc/GeneralUpdate.Core) |
-| Server | `src\Server` | 返回版本信息、接收更新报告、提供补丁下载 | [GeneralUpdate.Core](../doc/GeneralUpdate.Core) |
-| Packet | `src\Server\wwwroot\packages` | 可下载的 `.zip` 更新包和 `versions.json` 元数据 | [GeneralUpdate.Tools](./GeneralUpdate.PacketTool) |
-| Tools | GeneralUpdate.Tools 仓库 | 生成补丁包、Hash、OSS 清单、manifest 和仿真报告 | [GeneralUpdate.Tools](./GeneralUpdate.PacketTool) |
-| Bowl | Hub Samples 中集成 | 监控进程异常并导出失败信息 | [GeneralUpdate.Bowl](../doc/GeneralUpdate.Bowl) |
-| Differential | Hub Samples + Core 默认集成 | 对 old/new 文件生成差分，并在更新阶段应用 | [GeneralUpdate.Differential](../doc/GeneralUpdate.Differential) |
+## 更新流程总览
 
-## Step 1：准备仓库和运行环境
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                     GeneralUpdate 完整更新流程                        │
+└──────────────────────────────────────────────────────────────────────┘
 
-克隆 Samples 仓库，并确认本机可以执行 `dotnet`：
-
-```powershell
-git clone https://github.com/GeneralLibrary/GeneralUpdate-Samples.git
-cd GeneralUpdate-Samples
-dotnet --info
+  ① 版本检查               ② 下载包               ③ 应用更新
+  ┌──────────┐           ┌──────────┐           ┌──────────┐
+  │  Client  │──POST──→  │  Server  │           │ Upgrade  │
+  │ (主程序)  │←─JSON───  │ (更新服务)│           │ (升级进程) │
+  └────┬─────┘           └────┬─────┘           └────┬─────┘
+       │                      │                      │
+       │  POST /Verification  │                      │
+       │  {version, platform} │                      │
+       │ ────────────────────→│                      │
+       │                      │                      │
+       │  [{version, url,     │                      │
+       │    hash, size}]      │                      │
+       │ ←────────────────────│                      │
+       │                      │                      │
+       │  GET /File/Download  │                      │
+       │ ────────────────────→│                      │
+       │                      │                      │
+       │  .zip packages       │                      │
+       │ ←────────────────────│                      │
+       │                      │                      │
+       │  [写入 IPC 加密契约]   │                      │
+       │  [启动 Upgrade.exe]   │                      │
+       │ ────────────────────────────────────────────→│
+       │                      │                      │
+       │                      │    [读取 IPC 数据]    │
+       │                      │    [校验 Hash]        │
+       │                      │    [解压 → 覆盖]      │
+       │                      │    [启动新版本 Client] │
+       │                      │                      │
+       │ ←────────────────────────────────────────────│
+       │  [新版本运行中 ✓]     │                      │
+       │                      │                      │
 ```
 
-当前 Samples Hub 面向 `net10.0`，需要安装 [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)。
+| 角色 | 在项目中的位置 | 负责什么 |
+| --- | --- | --- |
+| Client | `MyApp.exe`（你自己的主程序） | 检查更新 → 下载包 → 启动 Upgrade |
+| Upgrade | `MyApp.Upgrade.exe`（独立的升级进程） | 校验 Hash → 解压覆盖 → 启动新版 Client |
+| Server | `GeneralUpdate-Samples/src/Server` | 返回版本信息、接收更新报告、提供补丁下载 |
+| Tools | GeneralUpdate.Tools | 生成 `generalupdate.manifest.json`，串联 Client 与 Upgrade |
 
-**预期结果**：`dotnet --info` 能输出 .NET 10 SDK 信息，`src` 目录下能看到 `Hub`、`Server`、`ImDiskDriver`、`content_client`、`content_upgrade`、`gen_packages.ps1`、`Run.cmd`、`Run.ps1` 等。
+---
 
-## Step 2：先跑通内置更新样例
+## Phase 1：环境准备
 
-### 2.1 首次运行 — 编译本地组件 DLL
+### 安装清单
 
-从源码克隆下来后，`src\Hub\libs\` 目录下包含预编译的 DLL 文件。如果你修改了 GeneralUpdate 组件的源码，可以重新编译并复制 DLL：
+| 项 | 要求 | 验证命令 |
+| --- | --- | --- |
+| .NET SDK | 8.0+（推荐 10.0） | `dotnet --version` |
+| Git | 任意版本 | `git --version` |
 
-```powershell
-cd src
-.\Run.ps1 -BuildLibs
+### 新建项目
+
+打开终端，创建 Client 和 Upgrade 两个控制台项目：
+
+```bash
+dotnet new console -n MyApp
+dotnet new console -n MyApp.Upgrade
+
+cd MyApp
+dotnet add package GeneralUpdate.Core
+
+cd ../MyApp.Upgrade
+dotnet add package GeneralUpdate.Core
 ```
 
-`-BuildLibs` 会自动查找同级目录 `..\GeneralUpdate\src\c#` 下的源码，依次编译 `GeneralUpdate.Differential`、`GeneralUpdate.Core`、`GeneralUpdate.Bowl`、`GeneralUpdate.Extension`、`GeneralUpdate.Drivelution`，并将 DLL 复制到 `src\Hub\libs\`。
+**预期结果**：两个项目目录下都有 `GeneralUpdate.Core` 的 NuGet 引用。
 
-如果只想快速体验（无需编译源码，使用预置 DLL），直接运行即可：
+---
 
-```powershell
-cd src
-.\Run.cmd
-```
+## Phase 2：集成 Client 代码
 
-或使用 PowerShell：
-
-```powershell
-cd src
-.\Run.ps1
-```
-
-### 2.2 示例菜单
-
-启动后会看到交互式菜单：
-
-```text
-  ╔══════════════════════════════════════╗
-  ║    GeneralUpdate 示例浏览器          ║
-  ╚══════════════════════════════════════╝
-
-  配置: http://localhost:5000
-
-  ═══════════════════════════════════
-    1. 完整更新 — 版本发现→下载→应用
-    2. OSS 更新
-    3. 静默更新
-    4. 推送更新
-    5. 差分算法
-    6. 压缩演示
-    7. 扩展管理
-    8. Bowl 进程守护
-    9. ImDisk 快速安装
-  ───────────────────────────────────
-    0. 退出 (Exit)
-  ═══════════════════════════════════
-```
-
-### 2.3 运行第一个样例
-
-输入 `1` 并按回车，选择"完整更新"。Hub 会自动：
-
-1. **启动 Server**（如果尚未运行）— 输出 `[Server] 启动中... ✓`
-2. 在 `mock_app` 目录创建模拟的 v1.0.0.0 应用文件
-3. 通过 `GeneralUpdateBootstrap` 向 `http://localhost:5000/Upgrade/Verification` 请求更新
-4. 下载新版本包并应用更新
-5. 打印更新后的文件列表
-
-**预期结果**：
-
-- Server 控制台显示 `GeneralUpdate Sample Upgrade Server`，监听 `http://localhost:5000/`
-- Hub 控制台显示版本发现、下载进度、更新完成信息
-- `mock_app` 目录中的文件从 v1.0.0.0 更新到 v2.0.0.0
-
-## Step 3：看懂 Server 返回了什么
-
-Hub 中每个 Sample 通过 `appsettings.json` 统一配置，再由各 Sample 的代码设置更新参数。查看 [src\Hub\appsettings.json](https://github.com/GeneralLibrary/GeneralUpdate-Samples/blob/main/src/Hub/appsettings.json)：
-
-```json
-{
-  "ServerUrl": "http://localhost:5000",
-  "AppSecretKey": "dfeb5833-975e-4afb-88f1-6278ee9aeff6",
-  "ProductId": "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
-  "ClientVersion": "1.0.0.0",
-  "UpgradeClientVersion": "1.0.0.0",
-  "MainAppName": "Hub.exe",
-  "UpgradeAppName": "Hub.exe"
-}
-```
-
-"完整更新"样例中 [CompleteUpdateSample.cs](https://github.com/GeneralLibrary/GeneralUpdate-Samples/blob/main/src/Hub/Samples/CompleteUpdateSample.cs) 使用 `UpdateRequest` 设置更新参数：
+> **在 `MyApp/Program.cs` 中粘贴以下全部内容。Client 负责：检查更新 → 下载包 → 启动 Upgrade。**
 
 ```csharp
+using GeneralUpdate.Core;
+using GeneralUpdate.Core.Configuration;
+using GeneralUpdate.Core.Event;
+
+// ================================================================
+// Client — 主程序入口，负责检测和下载更新
+// ================================================================
+
+// 只需设置 3 个 secret。MainAppName、ClientVersion、UpdateAppName
+// 等身份字段由框架自动从 generalupdate.manifest.json 发现，无需手写。
 var request = new UpdateRequest
 {
-    UpdateUrl = $"{config.ServerUrl}/Upgrade/Verification",
-    ReportUrl = $"{config.ServerUrl}/Upgrade/Report",
-    AppSecretKey = config.AppSecretKey,
-    InstallPath = mockAppDir,
-    ClientVersion = config.ClientVersion,
-    MainAppName = config.MainAppName,
-    UpdateAppName = config.UpgradeAppName,
-    ProductId = config.ProductId
+    UpdateUrl    = "http://localhost:5000/Upgrade/Verification",
+    ReportUrl    = "http://localhost:5000/Upgrade/Report",
+    AppSecretKey = "dfeb5833-975e-4afb-88f1-6278ee9aeff6",
 };
-```
 
-Server 的 `POST /Upgrade/Verification` 会读取客户端版本、AppType、Platform、ProductId 和 UpgradeMode，然后从 `versions.json` 里筛选更高版本。返回结果包含 `RecordId`、`Name`、`Hash`、`Url`、`Version`、`AppType`、`Platform`、`Format`、`Size` 等字段。
-
-**预期结果**：当 Client 当前版本是 `1.0.0.0`，而 `versions.json` 里存在 `2.0.0.0` 包时，Client 会收到可更新版本。
-
-## Step 4：理解 GeneralUpdateBootstrap 的流程
-
-每个 Sample 的核心都是一个 `GeneralUpdateBootstrap` 实例。以"完整更新"为例：
-
-```csharp
-var bootstrap = new GeneralUpdateBootstrap()
+await new GeneralUpdateBootstrap()
     .SetConfig(request)
     .SetOption(Option.AppType, AppType.Client)
-    .AddListenerUpdateInfo((_, e) => { /* 处理版本信息 */ })
-    .AddListenerMultiDownloadStatistics((_, e) => { /* 处理下载进度 */ })
-    .AddListenerException((_, e) => { /* 处理异常 */ });
-
-await bootstrap.LaunchAsync();
+    .AddListenerUpdateInfo((_, e) =>
+    {
+        Console.WriteLine($"发现 {e.Info?.Body?.Count ?? 0} 个可用更新");
+        if (e.Info?.Body != null)
+        {
+            foreach (var v in e.Info.Body)
+                Console.WriteLine($"  v{v.Version} — {v.Name} ({v.Size} bytes)");
+        }
+    })
+    .AddListenerMultiDownloadStatistics((_, e) =>
+    {
+        Console.WriteLine($"\r下载: {e.ProgressPercentage:F0}% {e.Speed}");
+    })
+    .AddListenerMultiDownloadCompleted((_, e) =>
+    {
+        Console.WriteLine();
+        Console.WriteLine($"下载 {(e.IsCompleted ? "✓ 完成" : "✗ 失败")}");
+    })
+    .AddListenerException((_, e) =>
+    {
+        Console.WriteLine($"异常: {e.Exception.Message}");
+    })
+    .LaunchAsync();
 ```
 
-`GeneralUpdate.Core` 统一了原来的 `GeneralUpdate.ClientCore` 和 `GeneralUpdate.Common`，现在只需要引用一个 NuGet 包即可获得全部能力：
+### 为什么只设 3 个参数？
 
-- **客户端更新管理**：版本检查、更新包下载、完整性验证、拉起升级程序
-- **升级执行引擎**：独立进程升级、文件替换、差分包应用、驱动安装
-- **公共基础设施**：生命周期追踪、下载引擎、序列化等底层能力
+`ClientStrategy` 在执行时会自动调用 `AppMetadataDiscoverer.Discover()`，从 `generalupdate.manifest.json`（Phase 4 用 Tools 生成）中读取身份字段并补全 `UpdateRequest`：
 
-**预期结果**：`LaunchAsync()` 执行完成后，目标目录的文件已被更新到新版本。
+| 字段 | 谁负责 | 说明 |
+| --- | --- | --- |
+| `UpdateUrl` | **你写代码** | Server 验证接口地址 |
+| `ReportUrl` | **你写代码** | Server 报告接口地址 |
+| `AppSecretKey` | **你写代码** | 应用密钥 |
+| `MainAppName` | **框架自动发现** | 从 manifest 读取 |
+| `ClientVersion` | **框架自动发现** | 从 manifest 读取 |
+| `UpdateAppName` | **框架自动发现** | 从 manifest 读取 |
+| `ProductId` | **框架自动发现** | 从 manifest 读取 |
+| `UpdatePath` | **框架自动发现** | 从 manifest 读取 |
+| `InstallPath` | **默认值** | `AppDomain.CurrentDomain.BaseDirectory` |
 
-## Step 5：用 Tools 生成自己的补丁包
+如果你不想写 `UpdateRequest`，还可以用更简短的 `SetSource()`：
 
-当你已经有两个发布目录时，可以用 GeneralUpdate.Tools 的 Patch 页面生成补丁：
-
-| Tools 字段 | 应该选择什么 |
-| --- | --- |
-| Old Directory | 用户当前安装的旧版本目录，例如 `publish\v1.0.0` |
-| New Directory | 你准备发布的新版本目录，例如 `publish\v2.0.0` |
-| Package Name | 建议包含版本，例如 `client_1.0.0_to_2.0.0` |
-| Version | 目标版本，例如 `2.0.0` |
-| Output Directory | 保存补丁 ZIP 的目录 |
-
-Samples 仓库也提供了 `gen_packages.ps1` 脚本用于快速生成测试包：
-
-```powershell
-cd src
-.\gen_packages.ps1
+```csharp
+await new GeneralUpdateBootstrap()
+    .SetSource("http://localhost:5000/Upgrade/Verification",
+               "dfeb5833-975e-4afb-88f1-6278ee9aeff6",
+               "http://localhost:5000/Upgrade/Report")
+    .SetOption(Option.AppType, AppType.Client)
+    // ... listeners
+    .LaunchAsync();
 ```
 
-该脚本使用 `src\content_client\v1.0.0.0\` 和 `src\content_client\v2.0.0.0\` 的内容生成测试补丁包，输出到 `src\Server\wwwroot\packages\`。
+Client 不直接应用更新——下载完成后写 IPC 加密契约 → 启动 Upgrade → 自身退出。
 
-Tools 会调用 Core 差分管线：旧文件和新文件不同则生成 `.patch`，新文件直接复制，删除的文件写入 `generalupdate.delete.json`，最后压缩为 ZIP。
+---
 
-**预期结果**：输出目录出现更新包 ZIP 文件，Server 的 `versions.json` 被更新。
+## Phase 3：集成 Upgrade 代码
 
-## Step 6：发布补丁包给 Server
+> **在 `MyApp.Upgrade/Program.cs` 中粘贴以下全部内容。Upgrade 比 Client 更简单——不需要 `SetConfig()`，所有参数通过加密 IPC 文件从 Client 传入。**
 
-Samples Server 默认从这里读取包：
+```csharp
+using GeneralUpdate.Core;
+using GeneralUpdate.Core.Configuration;
+using GeneralUpdate.Core.Event;
 
-```text
-src\Server\wwwroot\packages\
+// ================================================================
+// Upgrade — 独立的升级进程 (MyApp.Upgrade.exe)
+// 无需 SetConfig()，参数由 Client 通过加密 IPC 文件传入
+// ================================================================
+
+await new GeneralUpdateBootstrap()
+    .SetOption(Option.AppType, AppType.Upgrade)
+    .AddListenerMultiDownloadStatistics((_, e) =>
+    {
+        Console.WriteLine($"\r应用补丁: {e.ProgressPercentage:F0}%");
+    })
+    .AddListenerMultiDownloadCompleted((_, e) =>
+    {
+        Console.WriteLine();
+        Console.WriteLine($"补丁 {(e.IsCompleted ? "✓ 完成" : "✗ 失败")}");
+    })
+    .AddListenerException((_, e) =>
+    {
+        Console.WriteLine($"异常: {e.Exception.Message}");
+    })
+    .LaunchAsync();
 ```
 
-你需要把补丁 ZIP 放到该目录，并确保同目录下的 `versions.json` 包含对应记录。一条版本记录至少要让 Server 能匹配和下载：
+### Client vs Upgrade 差异
+
+| | Client | Upgrade |
+| --- | --- | --- |
+| `AppType` | `AppType.Client` | `AppType.Upgrade` |
+| `SetConfig()` | ✅ 必须，设置服务器地址、版本等 | ❌ 不需要，通过 IPC 从 Client 获取 |
+| 职责 | 检查版本 → 下载包 → 启动 Upgrade | Hash 校验 → 解压覆盖 → 启动新版 Client |
+| 谁启动谁 | 由用户直接启动 | 由 Client 进程自动启动 |
+
+---
+
+## Phase 4：使用 Tools 生成项目结构
+
+> **Client 和 Upgrade 代码写好后，用 Tools 的配置生成器（Config 标签页）一键 `dotnet publish` 并生成 `generalupdate.manifest.json`。**
+
+### 操作步骤
+
+打开 **GeneralUpdate.Tools** → 切换到 **Config** 标签页（配置生成器）：
+
+1. **Client .csproj Path**：点击 Browse，选择 `MyApp.csproj`
+2. **Upgrade .csproj Path**：点击 Browse，选择 `MyApp.Upgrade.csproj`
+3. 点击 **Analyze**：Tools 解析两个 .csproj，自动填入：
+   - `MainAppName`：来自 Client 项目的 AssemblyName（如 `MyApp.exe`）
+   - `UpdateAppName`：来自 Upgrade 项目的 AssemblyName（如 `MyApp.Upgrade.exe`）
+   - `ClientVersion` / `UpgradeClientVersion`：默认 `1.0.0`，按需修改
+4. 检查自动填入的字段，确认 `UpdatePath` 为 `update/`（默认值）
+5. 点击 **Generate Sample**：Tools 依次执行：
+   - `dotnet publish` Client → 输出到根目录
+   - `dotnet publish` Upgrade → 输出到 `update/` 子目录
+   - 写入 `generalupdate.manifest.json` 到根目录
+
+### 发布后的目录结构
+
+Tools 可以帮助你一键 `dotnet publish` 并组装输出目录（通过 Config 标签页的 Sample Publisher）。最终结构如下：
+
+```
+publish/
+├── MyApp.exe                   # Client publish 产物（Phase 2）
+├── MyApp.dll
+├── GeneralUpdate.Core.dll
+├── generalupdate.manifest.json # Tools 生成，放根目录，框架自动发现
+└── update/                     # Upgrade publish 产物（Phase 3），子目录名来自 manifest 的 updatePath
+    ├── MyApp.Upgrade.exe
+    └── MyApp.Upgrade.dll
+```
+
+> **注意**：`MyApp.Upgrade.exe` 不在根目录，而是在 `update/` 子目录下。框架根据 manifest 的 `updatePath` 字段（默认 `"update/"`）找到并启动它。
+
+### `generalupdate.manifest.json` 示例
 
 ```json
 {
-  "PacketName": "client_1.0.0_to_2.0.0",
-  "Hash": "补丁ZIP的sha256",
-  "Version": "2.0.0.0",
-  "Url": "http://localhost:5000/File/Download/补丁ZIP的sha256",
-  "AppType": 1,
-  "Platform": 1,
-  "ProductId": "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
-  "Format": ".zip",
-  "IsCrossVersion": true,
-  "FromVersion": "1.0.0.0",
-  "ToVersion": "2.0.0.0"
+  "mainAppName": "MyApp.exe",
+  "clientVersion": "1.0.0.0",
+  "updateAppName": "MyApp.Upgrade.exe",
+  "upgradeClientVersion": "1.0.0.0",
+  "appType": "Client",
+  "productId": "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
+  "updatePath": "update/"
 }
 ```
 
-Hash 可以用 Tools 的 OSS 页面计算，也可以在 CI 中计算。Server 下载接口是 `GET /File/Download/{hash}`，支持 HTTP Range，便于断点续传。
+> **注意：manifest 只存身份/结构信息，不存 secret。** `UpdateUrl`、`ReportUrl`、`AppSecretKey` 等敏感字段始终写在代码里，由 Phase 2 的 `request.XXX = "..."` 提供。
 
-**预期结果**：重启 Hub 后运行样例，Server 启动横幅会列出加载到的版本；请求时能拿到你刚发布的版本记录。
+---
 
-## Step 7：探索其他内置样例
+## Phase 5：启动 Server
 
-Hub 提供了 9 个内置样例，覆盖了 GeneralUpdate 的主要使用场景：
+> **Client / Upgrade / manifest 全部就绪，启动 Server 准备端到端验证。**
 
-| 编号 | 样例 | 说明 |
+```bash
+git clone https://github.com/GeneralLibrary/GeneralUpdate-Samples.git
+cd GeneralUpdate-Samples/src/Server
+dotnet run
+```
+
+预期输出：
+
+```
+╔══════════════════════════════════════════════════╗
+║     GeneralUpdate Sample Upgrade Server          ║
+╠══════════════════════════════════════════════════╣
+║  Verification: http://localhost:5000/Upgrade/Verification
+║  Report:       http://localhost:5000/Upgrade/Report
+║  Download:     http://localhost:5000/File/Download/{hash}
+║  Packages:     N version(s) loaded
+╚══════════════════════════════════════════════════╝
+```
+
+### Server 三端点速查
+
+| 端点 | 方法 | 用途 |
 | --- | --- | --- |
-| 1 | 完整更新 | 标准更新闭环：版本发现→下载→应用 |
-| 2 | OSS 更新 | 基于对象存储的更新模式 |
-| 3 | 静默更新 | 后台下载，用户无感知 |
-| 4 | 推送更新 | 基于 SignalR 的推送实时更新 |
-| 5 | 差分算法 | 二进制差分 Clean/Dirty 演示 |
-| 6 | 压缩演示 | 压缩中间件演示 |
-| 7 | 扩展管理 | 插件/扩展的查询、下载、安装 |
-| 8 | Bowl 进程守护 | 进程崩溃监控与 Dump 收集 |
-| 9 | ImDisk 快速安装 | 驱动级快速安装演示 |
+| `/Upgrade/Verification` | POST | Client 上报当前版本 → Server 返回可用更新列表 |
+| `/Upgrade/Report` | POST | Client 上报更新结果（成功 / 失败） |
+| `/File/Download/{hash}` | GET | 下载更新包（支持 HTTP Range 断点续传） |
 
-建议依次运行每个样例，观察它们在 `mock_app` 目录中的操作结果。
+Server 读取 `wwwroot/packages/versions.json` 中的包元数据并对外提供下载。
 
-**预期结果**：每个样例运行后，控制台会明确显示该场景的关键步骤和结果。
+**快速验证**：
+
+```bash
+curl -X POST http://localhost:5000/Upgrade/Verification \
+  -H "Content-Type: application/json" \
+  -d '{"Version":"1.0.0.0"}'
+```
+
+应返回包含可用更新版本的 JSON 响应。
+
+---
+
+## Phase 6：端到端运行验证
+
+```
+# 终端 1 — 确保 Server 在运行
+cd GeneralUpdate-Samples/src/Server && dotnet run
+
+# 终端 2 — 运行 Client
+cd MyApp && dotnet run
+```
+
+### 完整预期输出
+
+```
+Client:
+  [UpdateInfo] 发现 1 个可用更新
+    v2.0.0.0 — client_1.0.0_to_2.0.0 (xxxxx bytes)
+  下载: 45% 1.2MB/s
+  下载: 100%
+  下载 ✓ 完成
+  → 启动 MyApp.Upgrade.exe...
+
+Upgrade:
+  应用补丁: 50%
+  应用补丁: 100%
+  补丁 ✓ 完成
+  → 启动 MyApp.exe (新版本)...
+
+Client (新版本):
+  MyApp v2.0.0.0 ✓
+```
+
+### 排查清单
+
+| 现象 | 检查 |
+| --- | --- |
+| Client 连不上 Server | `curl http://localhost:5000/Upgrade/Verification` 确认 Server 在跑 |
+| 返回"Already up to date" | `versions.json` 中是否有比 `ClientVersion` 更高的版本 |
+| 下载完成但未启动 Upgrade | `MyApp.Upgrade.exe` 是否在 `update/` 子目录下，manifest 的 `updatePath` 是否正确 |
+| Upgrade 报错退出 | 检查目录写入权限、杀毒软件是否拦截 |
+| 端口被占用 | 修改 Server 启动参数 `--Urls http://0.0.0.0:5001`，同步修改 Client 的 `UpdateUrl` |
+
+---
 
 ## 下一步
 
-跑通这条链路后，建议按顺序阅读：
+跑通这条闭环后，建议按顺序深入阅读：
 
-1. [GeneralUpdate.Core](../doc/GeneralUpdate.Core)：更新策略、事件通知、静默更新、manifest 极简配置。
-2. [GeneralUpdate.Tools](./GeneralUpdate.PacketTool)：补丁包、Hash、OSS Config、Simulation。
-3. [GeneralUpdate.Differential](../doc/GeneralUpdate.Differential)：差分算法、并行处理和 Clean/Dirty。
-4. [GeneralUpdate.Bowl](../doc/GeneralUpdate.Bowl)：崩溃监控、备份和失败恢复。
-5. [GeneralUpdate.Tools](./GeneralUpdate.PacketTool)：补丁包、Hash、OSS Config、Simulation。
+1. [GeneralUpdate.Core](../doc/GeneralUpdate.Core)：更新策略、事件通知、静默更新、manifest 极简配置
+2. [GeneralUpdate.Differential](../doc/GeneralUpdate.Differential)：差分算法、并行处理和 Clean/Dirty
+3. [GeneralUpdate.Bowl](../doc/GeneralUpdate.Bowl)：崩溃监控、备份和失败恢复
+4. [GeneralUpdate.Tools](./GeneralUpdate.PacketTool)：补丁包、Hash、OSS Config、Simulation 的完整操作指南
 
-## Sample UI
+## 示例仓库
 
-示例程序界面预览：
-
-![](imgs\sampleclient.png)
-
-![](imgs\sampleupgrade.png)
-
-| 仓库地址 |
-| --- |
-| [ClientSample.sln](https://github.com/GeneralLibrary/GeneralUpdate-Samples/blob/main/src/Client/ClientSample.sln) |
-| [UpgradeSample.sln](https://github.com/GeneralLibrary/GeneralUpdate-Samples/blob/main/src/Upgrade/UpgradeSample.sln) |
+| 仓库 | 地址 |
+| --- | --- |
+| Samples（Server + Hub） | [GeneralUpdate-Samples](https://github.com/GeneralLibrary/GeneralUpdate-Samples) |
+| Tools（GUI 配置工具） | [GeneralUpdate.Tools](https://github.com/Juster/GeneralUpdate.Tools) |
+| Core（NuGet 包源码） | [GeneralUpdate](https://github.com/GeneralLibrary/GeneralUpdate) |

--- a/website/docs/quickstart/Beginner cookbook.md
+++ b/website/docs/quickstart/Beginner cookbook.md
@@ -29,7 +29,7 @@ title: 入门实战手册
   │ (主程序)  │←─JSON───  │ (更新服务)│           │ (升级进程) │
   └────┬─────┘           └────┬─────┘           └────┬─────┘
        │                      │                      │
-       │  POST /Verification  │                      │
+       │  POST /Upgrade/Verification               │                      │
        │  {version, platform} │                      │
        │ ────────────────────→│                      │
        │                      │                      │
@@ -354,7 +354,7 @@ Client (新版本):
 
 | 现象 | 检查 |
 | --- | --- |
-| Client 连不上 Server | `curl http://localhost:5000/Upgrade/Verification` 确认 Server 在跑 |
+| Client 连不上 Server | `curl -X POST http://localhost:5000/Upgrade/Verification` 确认 Server 在跑 |
 | 返回"Already up to date" | `versions.json` 中是否有比 `ClientVersion` 更高的版本 |
 | 下载完成但未启动 Upgrade | `MyApp.Upgrade.exe` 是否在 `update/` 子目录下，manifest 的 `updatePath` 是否正确 |
 | Upgrade 报错退出 | 检查目录写入权限、杀毒软件是否拦截 |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/quickstart/Beginner cookbook.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/quickstart/Beginner cookbook.md
@@ -3,257 +3,380 @@ sidebar_position: 3
 title: Beginner cookbook
 ---
 
+import ReactPlayer from 'react-player'
+
 # GeneralUpdate beginner cookbook
 
-This cookbook is for first-time GeneralUpdate users. The goal is not to explain every API at once, but to help you complete one full loop: discover an update, download a package, start the upgrade, apply the patch, and return to the new version. After that, each component's responsibility becomes much easier to understand.
+This cookbook is for first-time GeneralUpdate users. The goal is not to explain every API at once, but to take you from zero to a complete loop: write Client → write Upgrade → generate config with Tools → start Server → one command to verify the full "discover → download → apply → return to new version" flow.
 
-## Roles used in the flow
+<ReactPlayer
+  url='https://www.bilibili.com/video/BV12P9dBiEEh'
+  controls
+  width='100%'
+  style={{ borderRadius: '8px' }}
+/>
 
-| Role | Sample location | Responsibility | Deep dive |
-| --- | --- | --- | --- |
-| Hub | `src\Hub` | Interactive sample browser; run update scenarios via menu | [GeneralUpdate.Core](../doc/GeneralUpdate.Core) |
-| Server | `src\Server` | Returns version metadata, accepts reports, and serves package downloads | [GeneralUpdate.Core](../doc/GeneralUpdate.Core) |
-| Packet | `src\Server\wwwroot\packages` | Downloadable `.zip` packages and `versions.json` metadata | [GeneralUpdate.Tools](./GeneralUpdate.PacketTool) |
-| Tools | GeneralUpdate.Tools repository | Generates patch packages, hashes, OSS manifests, and simulation reports | [GeneralUpdate.Tools](./GeneralUpdate.PacketTool) |
-| Bowl | Integrated in Hub Samples | Monitors process failures and exports failure data | [GeneralUpdate.Bowl](../doc/GeneralUpdate.Bowl) |
-| Differential | Hub Samples + Core default integration | Generates old/new binary differences and applies them during updates | [GeneralUpdate.Differential](../doc/GeneralUpdate.Differential) |
+## Update flow overview
 
-## Step 1: Prepare the repository and runtime
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                  GeneralUpdate Complete Update Flow                  │
+└──────────────────────────────────────────────────────────────────────┘
 
-Clone the Samples repository and confirm that `dotnet` works:
-
-```powershell
-git clone https://github.com/GeneralLibrary/GeneralUpdate-Samples.git
-cd GeneralUpdate-Samples
-dotnet --info
+  ① Version Check         ② Download             ③ Apply
+  ┌──────────┐           ┌──────────┐           ┌──────────┐
+  │  Client  │──POST──→  │  Server  │           │ Upgrade  │
+  │ (Main App)│←─JSON───  │(Update   │           │ (Upgrade │
+  │          │           │ Service) │           │  Process) │
+  └────┬─────┘           └────┬─────┘           └────┬─────┘
+       │                      │                      │
+       │  POST /Verification  │                      │
+       │  {version, platform} │                      │
+       │ ────────────────────→│                      │
+       │                      │                      │
+       │  [{version, url,     │                      │
+       │    hash, size}]      │                      │
+       │ ←────────────────────│                      │
+       │                      │                      │
+       │  GET /File/Download  │                      │
+       │ ────────────────────→│                      │
+       │                      │                      │
+       │  .zip packages       │                      │
+       │ ←────────────────────│                      │
+       │                      │                      │
+       │  [Write IPC contract]│                      │
+       │  [Launch Upgrade.exe]│                      │
+       │ ────────────────────────────────────────────→│
+       │                      │                      │
+       │                      │    [Read IPC data]   │
+       │                      │    [Verify Hash]     │
+       │                      │    [Extract → Apply] │
+       │                      │    [Launch new Client]│
+       │                      │                      │
+       │ ←────────────────────────────────────────────│
+       │  [New version running ✓]                    │
+       │                      │                      │
 ```
 
-The Hub targets `net10.0`, so you need the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0).
+| Role | Location in project | Responsibility |
+| --- | --- | --- |
+| Client | `MyApp.exe` (your main app) | Check updates → download packages → launch Upgrade |
+| Upgrade | `MyApp.Upgrade.exe` (standalone upgrade process) | Verify hash → extract & overwrite → launch new Client |
+| Server | `GeneralUpdate-Samples/src/Server` | Return version info, accept reports, serve package downloads |
+| Tools | GeneralUpdate.Tools | Generate `generalupdate.manifest.json`, wire Client and Upgrade together |
 
-**Expected result**: `dotnet --info` prints the .NET 10 SDK, and the `src` directory contains `Hub`, `Server`, `ImDiskDriver`, `content_client`, `content_upgrade`, `gen_packages.ps1`, `Run.cmd`, `Run.ps1`, etc.
+---
 
-## Step 2: Run the built-in update sample
+## Phase 1: Environment setup
 
-### 2.1 First run — build local component DLLs
+### Prerequisites
 
-The `src\Hub\libs\` directory contains pre-built DLLs. If you modified the GeneralUpdate component source code, rebuild and copy the DLLs:
+| Item | Requirement | Verify |
+| --- | --- | --- |
+| .NET SDK | 8.0+ (10.0 recommended) | `dotnet --version` |
+| Git | Any version | `git --version` |
 
-```powershell
-cd src
-.\Run.ps1 -BuildLibs
+### Create projects
+
+Open a terminal and create two console projects:
+
+```bash
+dotnet new console -n MyApp
+dotnet new console -n MyApp.Upgrade
+
+cd MyApp
+dotnet add package GeneralUpdate.Core
+
+cd ../MyApp.Upgrade
+dotnet add package GeneralUpdate.Core
 ```
 
-`-BuildLibs` auto-detects the sibling `..\GeneralUpdate\src\c#` source tree, builds `GeneralUpdate.Differential`, `GeneralUpdate.Core`, `GeneralUpdate.Bowl`, `GeneralUpdate.Extension`, and `GeneralUpdate.Drivelution` in order, and copies the DLLs into `src\Hub\libs\`.
+**Expected result**: Both projects have `GeneralUpdate.Core` in their NuGet references.
 
-To try the samples quickly without building from source (using the pre-built DLLs), just run:
+---
 
-```powershell
-cd src
-.\Run.cmd
-```
+## Phase 2: Integrate Client code
 
-Or with PowerShell:
-
-```powershell
-cd src
-.\Run.ps1
-```
-
-### 2.2 Sample menu
-
-After startup you will see the interactive menu:
-
-```text
-  ╔══════════════════════════════════════╗
-  ║    GeneralUpdate Sample Browser      ║
-  ╚══════════════════════════════════════╝
-
-  Config: http://localhost:5000
-
-  ═══════════════════════════════════
-    1. Complete Update — discover → download → apply
-    2. OSS Update
-    3. Silent Update
-    4. Push Update
-    5. Differential Algorithm
-    6. Compression Demo
-    7. Extension Management
-    8. Bowl Process Guardian
-    9. ImDisk Quick Install
-  ───────────────────────────────────
-    0. Exit
-  ═══════════════════════════════════
-```
-
-### 2.3 Run the first sample
-
-Enter `1` and press Enter to select "Complete Update". Hub will automatically:
-
-1. **Start Server** (if not already running) — prints `[Server] Starting... ✓`
-2. Create simulated v1.0.0.0 app files in the `mock_app` directory
-3. Request updates from `http://localhost:5000/Upgrade/Verification` via `GeneralUpdateBootstrap`
-4. Download the new version package and apply the update
-5. Print the updated file list
-
-**Expected result**:
-
-- Server console shows `GeneralUpdate Sample Upgrade Server` listening on `http://localhost:5000/`
-- Hub console shows version discovery, download progress, and update completion
-- Files in `mock_app` are updated from v1.0.0.0 to v2.0.0.0
-
-## Step 3: Understand what Server returns
-
-Hub uses `appsettings.json` for shared configuration, and each Sample passes these values to `GeneralUpdateBootstrap`. See [src\Hub\appsettings.json](https://github.com/GeneralLibrary/GeneralUpdate-Samples/blob/main/src/Hub/appsettings.json):
-
-```json
-{
-  "ServerUrl": "http://localhost:5000",
-  "AppSecretKey": "dfeb5833-975e-4afb-88f1-6278ee9aeff6",
-  "ProductId": "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
-  "ClientVersion": "1.0.0.0",
-  "UpgradeClientVersion": "1.0.0.0",
-  "MainAppName": "Hub.exe",
-  "UpgradeAppName": "Hub.exe"
-}
-```
-
-The "Complete Update" sample in [CompleteUpdateSample.cs](https://github.com/GeneralLibrary/GeneralUpdate-Samples/blob/main/src/Hub/Samples/CompleteUpdateSample.cs) uses `UpdateRequest` to configure the update:
+> **Paste the following into `MyApp/Program.cs`. Client is responsible for: checking for updates → downloading packages → launching Upgrade.**
 
 ```csharp
+using GeneralUpdate.Core;
+using GeneralUpdate.Core.Configuration;
+using GeneralUpdate.Core.Event;
+
+// ================================================================
+// Client — main app entry point, handles update detection & download
+// ================================================================
+
+// Only the 3 secrets need to be in code. Identity fields (MainAppName,
+// ClientVersion, UpdateAppName, etc.) are auto-discovered by the framework
+// from generalupdate.manifest.json — no manual code required.
 var request = new UpdateRequest
 {
-    UpdateUrl = $"{config.ServerUrl}/Upgrade/Verification",
-    ReportUrl = $"{config.ServerUrl}/Upgrade/Report",
-    AppSecretKey = config.AppSecretKey,
-    InstallPath = mockAppDir,
-    ClientVersion = config.ClientVersion,
-    MainAppName = config.MainAppName,
-    UpdateAppName = config.UpgradeAppName,
-    ProductId = config.ProductId
+    UpdateUrl    = "http://localhost:5000/Upgrade/Verification",
+    ReportUrl    = "http://localhost:5000/Upgrade/Report",
+    AppSecretKey = "dfeb5833-975e-4afb-88f1-6278ee9aeff6",
 };
-```
 
-Server's `POST /Upgrade/Verification` reads client version, AppType, Platform, ProductId, and UpgradeMode, then filters higher versions from `versions.json`. Each returned item contains `RecordId`, `Name`, `Hash`, `Url`, `Version`, `AppType`, `Platform`, `Format`, `Size`, and other fields.
-
-**Expected result**: when Client is at `1.0.0.0` and `versions.json` contains `2.0.0.0`, Client receives available updates.
-
-## Step 4: Understand the GeneralUpdateBootstrap flow
-
-Each Sample is built around a `GeneralUpdateBootstrap` instance. Here's the "Complete Update" example:
-
-```csharp
-var bootstrap = new GeneralUpdateBootstrap()
+await new GeneralUpdateBootstrap()
     .SetConfig(request)
     .SetOption(Option.AppType, AppType.Client)
-    .AddListenerUpdateInfo((_, e) => { /* handle version info */ })
-    .AddListenerMultiDownloadStatistics((_, e) => { /* handle download progress */ })
-    .AddListenerException((_, e) => { /* handle exceptions */ });
-
-await bootstrap.LaunchAsync();
+    .AddListenerUpdateInfo((_, e) =>
+    {
+        Console.WriteLine($"Found {e.Info?.Body?.Count ?? 0} available update(s)");
+        if (e.Info?.Body != null)
+        {
+            foreach (var v in e.Info.Body)
+                Console.WriteLine($"  v{v.Version} — {v.Name} ({v.Size} bytes)");
+        }
+    })
+    .AddListenerMultiDownloadStatistics((_, e) =>
+    {
+        Console.WriteLine($"\rDownload: {e.ProgressPercentage:F0}% {e.Speed}");
+    })
+    .AddListenerMultiDownloadCompleted((_, e) =>
+    {
+        Console.WriteLine();
+        Console.WriteLine($"Download {(e.IsCompleted ? "✓ done" : "✗ failed")}");
+    })
+    .AddListenerException((_, e) =>
+    {
+        Console.WriteLine($"Error: {e.Exception.Message}");
+    })
+    .LaunchAsync();
 ```
 
-`GeneralUpdate.Core` now unifies the former `GeneralUpdate.ClientCore` and `GeneralUpdate.Common`. A single NuGet reference gives you all capabilities:
+### Why only 3 parameters?
 
-- **Client update management** (former ClientCore): version checks, package downloads, integrity validation, launching the upgrade process
-- **Upgrade execution engine** (former Core): standalone upgrade process, file replacement, differential patch application, driver installation
-- **Common infrastructure** (former Common): lifecycle tracing, download engine, serialization, and other low-level utilities
+`ClientStrategy` internally calls `AppMetadataDiscoverer.Discover()` during execution, which reads identity fields from `generalupdate.manifest.json` (generated by Tools in Phase 4) and fills in the `UpdateRequest` automatically:
 
-**Expected result**: after `LaunchAsync()` completes, the target directory files are updated to the new version.
+| Field | Who handles it | Notes |
+| --- | --- | --- |
+| `UpdateUrl` | **You (code)** | Server verification endpoint |
+| `ReportUrl` | **You (code)** | Server report endpoint |
+| `AppSecretKey` | **You (code)** | Application secret |
+| `MainAppName` | **Framework auto-discover** | Read from manifest |
+| `ClientVersion` | **Framework auto-discover** | Read from manifest |
+| `UpdateAppName` | **Framework auto-discover** | Read from manifest |
+| `ProductId` | **Framework auto-discover** | Read from manifest |
+| `UpdatePath` | **Framework auto-discover** | Read from manifest |
+| `InstallPath` | **Default** | `AppDomain.CurrentDomain.BaseDirectory` |
 
-## Step 5: Generate your own patch package with Tools
+If you prefer an even shorter form, use `SetSource()`:
 
-When you have two release directories, use the Patch page in GeneralUpdate.Tools:
-
-| Tools field | What to select |
-| --- | --- |
-| Old Directory | The version users currently have, such as `publish\v1.0.0` |
-| New Directory | The version you want to release, such as `publish\v2.0.0` |
-| Package Name | Include versions, such as `client_1.0.0_to_2.0.0` |
-| Version | Target version, such as `2.0.0` |
-| Output Directory | Directory where the patch ZIP should be saved |
-
-The Samples repo also provides `gen_packages.ps1` to quickly generate test packages:
-
-```powershell
-cd src
-.\gen_packages.ps1
+```csharp
+await new GeneralUpdateBootstrap()
+    .SetSource("http://localhost:5000/Upgrade/Verification",
+               "dfeb5833-975e-4afb-88f1-6278ee9aeff6",
+               "http://localhost:5000/Upgrade/Report")
+    .SetOption(Option.AppType, AppType.Client)
+    // ... listeners
+    .LaunchAsync();
 ```
 
-This script uses content from `src\content_client\v1.0.0.0\` and `src\content_client\v2.0.0.0\` to generate test patch packages and outputs them to `src\Server\wwwroot\packages\`.
+Client does NOT apply updates directly — after download: writes IPC contract → launches Upgrade → exits itself.
 
-Tools calls the Core differential pipeline: changed files become `.patch` files, new files are copied directly, deleted files are recorded in `generalupdate.delete.json`, and the result is compressed into a ZIP.
+---
 
-**Expected result**: update ZIP files appear in the output directory, and Server's `versions.json` is updated.
+## Phase 3: Integrate Upgrade code
 
-## Step 6: Publish the package to Server
+> **Paste the following into `MyApp.Upgrade/Program.cs`. Upgrade is simpler than Client — no `SetConfig()` needed, all parameters are passed via encrypted IPC from Client.**
 
-Samples Server reads packages from:
+```csharp
+using GeneralUpdate.Core;
+using GeneralUpdate.Core.Configuration;
+using GeneralUpdate.Core.Event;
 
-```text
-src\Server\wwwroot\packages\
+// ================================================================
+// Upgrade — standalone upgrade process (MyApp.Upgrade.exe)
+// No SetConfig() needed — params come via encrypted IPC from Client
+// ================================================================
+
+await new GeneralUpdateBootstrap()
+    .SetOption(Option.AppType, AppType.Upgrade)
+    .AddListenerMultiDownloadStatistics((_, e) =>
+    {
+        Console.WriteLine($"\rApplying: {e.ProgressPercentage:F0}%");
+    })
+    .AddListenerMultiDownloadCompleted((_, e) =>
+    {
+        Console.WriteLine();
+        Console.WriteLine($"Patch {(e.IsCompleted ? "✓ done" : "✗ failed")}");
+    })
+    .AddListenerException((_, e) =>
+    {
+        Console.WriteLine($"Error: {e.Exception.Message}");
+    })
+    .LaunchAsync();
 ```
 
-Put the patch ZIP there and make sure `versions.json` includes the corresponding record. A version record needs enough data for Server to match and serve it:
+### Client vs Upgrade
+
+| | Client | Upgrade |
+| --- | --- | --- |
+| `AppType` | `AppType.Client` | `AppType.Upgrade` |
+| `SetConfig()` | ✅ Required — sets server URL, version, etc. | ❌ Not needed — received via IPC from Client |
+| Responsibility | Check version → download → launch Upgrade | Verify hash → extract & overwrite → launch new Client |
+| Started by | User | Client process |
+
+---
+
+## Phase 4: Generate project structure with Tools
+
+> **With Client and Upgrade code written, use Tools' Config tab to `dotnet publish` both projects and generate `generalupdate.manifest.json`.**
+
+### Steps
+
+Open **GeneralUpdate.Tools** → switch to the **Config** tab:
+
+1. **Client .csproj Path**: Click Browse and select `MyApp.csproj`
+2. **Upgrade .csproj Path**: Click Browse and select `MyApp.Upgrade.csproj`
+3. Click **Analyze**: Tools parses both .csproj files and auto-fills:
+   - `MainAppName`: from Client project's AssemblyName (e.g. `MyApp.exe`)
+   - `UpdateAppName`: from Upgrade project's AssemblyName (e.g. `MyApp.Upgrade.exe`)
+   - `ClientVersion` / `UpgradeClientVersion`: defaults to `1.0.0`, adjust as needed
+4. Review the auto-filled fields; confirm `UpdatePath` is `update/` (the default)
+5. Click **Generate Sample**: Tools executes:
+   - `dotnet publish` Client → output root
+   - `dotnet publish` Upgrade → `update/` subdirectory
+   - Writes `generalupdate.manifest.json` to output root
+
+### Published directory structure
+
+Tools can also `dotnet publish` both projects and assemble the output for you (via the Config tab's Sample Publisher). The final structure:
+
+```
+publish/
+├── MyApp.exe                   # Client publish output (Phase 2)
+├── MyApp.dll
+├── GeneralUpdate.Core.dll
+├── generalupdate.manifest.json # Generated by Tools, placed at root, auto-discovered
+└── update/                     # Upgrade publish output (Phase 3), subdirectory name from manifest's updatePath
+    ├── MyApp.Upgrade.exe
+    └── MyApp.Upgrade.dll
+```
+
+> **Note**: `MyApp.Upgrade.exe` lives in the `update/` subdirectory — not at the root. The framework locates and launches it based on the manifest's `updatePath` field (default `"update/"`).
+
+### `generalupdate.manifest.json` example
 
 ```json
 {
-  "PacketName": "client_1.0.0_to_2.0.0",
-  "Hash": "sha256-of-the-patch-zip",
-  "Version": "2.0.0.0",
-  "Url": "http://localhost:5000/File/Download/sha256-of-the-patch-zip",
-  "AppType": 1,
-  "Platform": 1,
-  "ProductId": "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
-  "Format": ".zip",
-  "IsCrossVersion": true,
-  "FromVersion": "1.0.0.0",
-  "ToVersion": "2.0.0.0"
+  "mainAppName": "MyApp.exe",
+  "clientVersion": "1.0.0.0",
+  "updateAppName": "MyApp.Upgrade.exe",
+  "upgradeClientVersion": "1.0.0.0",
+  "appType": "Client",
+  "productId": "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
+  "updatePath": "update/"
 }
 ```
 
-You can calculate the hash with the OSS page in Tools or in CI. The Server download endpoint is `GET /File/Download/{hash}` and supports HTTP Range requests for resume.
+> **Note: manifest stores identity/structure only — never secrets.** `UpdateUrl`, `ReportUrl`, and `AppSecretKey` are always set in code, via Phase 2's `request.XXX = "..."` assignments.
 
-**Expected result**: after restarting Hub and running a sample, the Server startup banner lists the loaded versions; the sample can discover your new version record.
+---
 
-## Step 7: Explore the other built-in samples
+## Phase 5: Start the Server
 
-Hub provides 9 built-in samples covering GeneralUpdate's main use cases:
+> **Client / Upgrade / manifest are all ready — start the Server for end-to-end verification.**
 
-| # | Sample | Description |
+```bash
+git clone https://github.com/GeneralLibrary/GeneralUpdate-Samples.git
+cd GeneralUpdate-Samples/src/Server
+dotnet run
+```
+
+Expected output:
+
+```
+╔══════════════════════════════════════════════════╗
+║     GeneralUpdate Sample Upgrade Server          ║
+╠══════════════════════════════════════════════════╣
+║  Verification: http://localhost:5000/Upgrade/Verification
+║  Report:       http://localhost:5000/Upgrade/Report
+║  Download:     http://localhost:5000/File/Download/{hash}
+║  Packages:     N version(s) loaded
+╚══════════════════════════════════════════════════╝
+```
+
+### Server endpoints
+
+| Endpoint | Method | Purpose |
 | --- | --- | --- |
-| 1 | Complete Update | Standard update loop: discover → download → apply |
-| 2 | OSS Update | Object Storage-based update mode |
-| 3 | Silent Update | Background download, no user disruption |
-| 4 | Push Update | SignalR-based real-time push update |
-| 5 | Differential Algorithm | Binary diff Clean/Dirty demo |
-| 6 | Compression Demo | Compression middleware demo |
-| 7 | Extension Management | Plugin/extension query, download, install |
-| 8 | Bowl Process Guardian | Process crash monitoring and Dump collection |
-| 9 | ImDisk Quick Install | Driver-level quick install demo |
+| `/Upgrade/Verification` | POST | Client reports current version → Server returns available updates |
+| `/Upgrade/Report` | POST | Client reports update result (success / failure) |
+| `/File/Download/{hash}` | GET | Download package (supports HTTP Range for resume) |
 
-Try running each sample and observe the results in the `mock_app` directory.
+The Server reads package metadata from `wwwroot/packages/versions.json` and serves them.
 
-**Expected result**: each sample prints the key steps and results for its scenario.
+**Quick check**:
+
+```bash
+curl -X POST http://localhost:5000/Upgrade/Verification \
+  -H "Content-Type: application/json" \
+  -d '{"Version":"1.0.0.0"}'
+```
+
+Should return a JSON response with available update versions.
+
+---
+
+## Phase 6: End-to-end verification
+
+```
+# Terminal 1 — ensure Server is running
+cd GeneralUpdate-Samples/src/Server && dotnet run
+
+# Terminal 2 — run Client
+cd MyApp && dotnet run
+```
+
+### Expected complete output
+
+```
+Client:
+  [UpdateInfo] Found 1 available update(s)
+    v2.0.0.0 — client_1.0.0_to_2.0.0 (xxxxx bytes)
+  Download: 45% 1.2MB/s
+  Download: 100%
+  Download ✓ done
+  → Launching MyApp.Upgrade.exe...
+
+Upgrade:
+  Applying: 50%
+  Applying: 100%
+  Patch ✓ done
+  → Launching MyApp.exe (new version)...
+
+Client (new version):
+  MyApp v2.0.0.0 ✓
+```
+
+### Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| Client can't reach Server | `curl http://localhost:5000/Upgrade/Verification` to confirm Server is running |
+| "Already up to date" response | Make sure `versions.json` has a version higher than `ClientVersion` |
+| Download finishes but Upgrade doesn't start | Is `MyApp.Upgrade.exe` in the `update/` subdirectory? Is manifest's `updatePath` correct? |
+| Upgrade crashes | Check directory write permissions, antivirus interference |
+| Port already in use | Change Server args to `--Urls http://0.0.0.0:5001` and update Client's `UpdateUrl` |
+
+---
 
 ## Next steps
 
 After this flow works, read these pages in order:
 
-1. [GeneralUpdate.Core](../doc/GeneralUpdate.Core): update strategies, event notifications, silent updates, and manifest-based minimal configuration.
-2. [GeneralUpdate.Tools](./GeneralUpdate.PacketTool): patch packages, Hash, OSS Config, and Simulation.
-3. [GeneralUpdate.Differential](../doc/GeneralUpdate.Differential): differential algorithms, parallel processing, and Clean/Dirty.
-4. [GeneralUpdate.Bowl](../doc/GeneralUpdate.Bowl): crash monitoring, backup, and failure recovery.
-5. [GeneralUpdate.Tools](./GeneralUpdate.PacketTool): patch packages, Hash, OSS Config, and Simulation.
+1. [GeneralUpdate.Core](../doc/GeneralUpdate.Core): update strategies, event notifications, silent updates, and manifest-based minimal configuration
+2. [GeneralUpdate.Differential](../doc/GeneralUpdate.Differential): differential algorithms, parallel processing, and Clean/Dirty
+3. [GeneralUpdate.Bowl](../doc/GeneralUpdate.Bowl): crash monitoring, backup, and failure recovery
+4. [GeneralUpdate.Tools](./GeneralUpdate.PacketTool): complete guides for patches, hashes, OSS config, and simulation
 
-## Sample UI
+## Sample repositories
 
-Sample application interface preview:
-
-![](imgs\sampleclient.png)
-
-![](imgs\sampleupgrade.png)
-
-| Repository |
-| --- |
-| [ClientSample.sln](https://github.com/GeneralLibrary/GeneralUpdate-Samples/blob/main/src/Client/ClientSample.sln) |
-| [UpgradeSample.sln](https://github.com/GeneralLibrary/GeneralUpdate-Samples/blob/main/src/Upgrade/UpgradeSample.sln) |
+| Repository | URL |
+| --- | --- |
+| Samples (Server + Hub) | [GeneralUpdate-Samples](https://github.com/GeneralLibrary/GeneralUpdate-Samples) |
+| Tools (GUI config tool) | [GeneralUpdate.Tools](https://github.com/Juster/GeneralUpdate.Tools) |
+| Core (NuGet package source) | [GeneralUpdate](https://github.com/GeneralLibrary/GeneralUpdate) |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/quickstart/Beginner cookbook.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/quickstart/Beginner cookbook.md
@@ -3,17 +3,17 @@ sidebar_position: 3
 title: Beginner cookbook
 ---
 
-import ReactPlayer from 'react-player'
-
 # GeneralUpdate beginner cookbook
 
 This cookbook is for first-time GeneralUpdate users. The goal is not to explain every API at once, but to take you from zero to a complete loop: write Client → write Upgrade → generate config with Tools → start Server → one command to verify the full "discover → download → apply → return to new version" flow.
 
-<ReactPlayer
-  url='https://www.bilibili.com/video/BV12P9dBiEEh'
-  controls
-  width='100%'
-  style={{ borderRadius: '8px' }}
+<iframe
+  src="//player.bilibili.com/player.html?bvid=BV12P9dBiEEh&page=1"
+  width="100%"
+  height="480"
+  style={{ borderRadius: '8px', border: 'none' }}
+  allowFullScreen
+  scrolling="no"
 />
 
 ## Update flow overview

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/quickstart/Beginner cookbook.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/quickstart/Beginner cookbook.md
@@ -30,7 +30,7 @@ This cookbook is for first-time GeneralUpdate users. The goal is not to explain 
   │          │           │ Service) │           │  Process) │
   └────┬─────┘           └────┬─────┘           └────┬─────┘
        │                      │                      │
-       │  POST /Verification  │                      │
+       │  POST /Upgrade/Verification               │                      │
        │  {version, platform} │                      │
        │ ────────────────────→│                      │
        │                      │                      │
@@ -356,7 +356,7 @@ Client (new version):
 
 | Symptom | Check |
 | --- | --- |
-| Client can't reach Server | `curl http://localhost:5000/Upgrade/Verification` to confirm Server is running |
+| Client can't reach Server | `curl -X POST http://localhost:5000/Upgrade/Verification` to confirm Server is running |
 | "Already up to date" response | Make sure `versions.json` has a version higher than `ClientVersion` |
 | Download finishes but Upgrade doesn't start | Is `MyApp.Upgrade.exe` in the `update/` subdirectory? Is manifest's `updatePath` correct? |
 | Upgrade crashes | Check directory write permissions, antivirus interference |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quickstart/Beginner cookbook.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quickstart/Beginner cookbook.md
@@ -3,17 +3,17 @@ sidebar_position: 3
 title: 入门实战手册
 ---
 
-import ReactPlayer from 'react-player'
-
 # GeneralUpdate 入门实战手册
 
 这篇手册面向第一次接触 GeneralUpdate 的开发者。目标不是一次讲完所有 API，而是让你从零开始，写完 Client → 写完 Upgrade → 用 Tools 生成配置 → 启动 Server → 一条命令跑通完整的"发现更新 → 下载 → 应用 → 回到新版本"闭环。
 
-<ReactPlayer
-  url='https://www.bilibili.com/video/BV12P9dBiEEh'
-  controls
-  width='100%'
-  style={{ borderRadius: '8px' }}
+<iframe
+  src="//player.bilibili.com/player.html?bvid=BV12P9dBiEEh&page=1"
+  width="100%"
+  height="480"
+  style={{ borderRadius: '8px', border: 'none' }}
+  allowFullScreen
+  scrolling="no"
 />
 
 ## 更新流程总览

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quickstart/Beginner cookbook.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quickstart/Beginner cookbook.md
@@ -3,257 +3,378 @@ sidebar_position: 3
 title: 入门实战手册
 ---
 
+import ReactPlayer from 'react-player'
+
 # GeneralUpdate 入门实战手册
 
-这篇手册面向第一次接触 GeneralUpdate 的开发者。目标不是一次讲完所有 API，而是让你先跑通一次"发现更新 → 下载补丁 → 启动升级 → 应用补丁 → 回到新版本"的闭环，然后知道每个组件在流程里负责什么。
+这篇手册面向第一次接触 GeneralUpdate 的开发者。目标不是一次讲完所有 API，而是让你从零开始，写完 Client → 写完 Upgrade → 用 Tools 生成配置 → 启动 Server → 一条命令跑通完整的"发现更新 → 下载 → 应用 → 回到新版本"闭环。
 
-## 你会用到哪些角色
+<ReactPlayer
+  url='https://www.bilibili.com/video/BV12P9dBiEEh'
+  controls
+  width='100%'
+  style={{ borderRadius: '8px' }}
+/>
 
-| 角色 | 在样例中的位置 | 负责什么 | 深入阅读 |
-| --- | --- | --- | --- |
-| Hub | `src\Hub` | 交互式示例浏览器，通过菜单选择并运行各类更新场景 | [GeneralUpdate.Core](../doc/GeneralUpdate.Core) |
-| Server | `src\Server` | 返回版本信息、接收更新报告、提供补丁下载 | [GeneralUpdate.Core](../doc/GeneralUpdate.Core) |
-| Packet | `src\Server\wwwroot\packages` | 可下载的 `.zip` 更新包和 `versions.json` 元数据 | [GeneralUpdate.Tools](./GeneralUpdate.PacketTool) |
-| Tools | GeneralUpdate.Tools 仓库 | 生成补丁包、Hash、OSS 清单、manifest 和仿真报告 | [GeneralUpdate.Tools](./GeneralUpdate.PacketTool) |
-| Bowl | Hub Samples 中集成 | 监控进程异常并导出失败信息 | [GeneralUpdate.Bowl](../doc/GeneralUpdate.Bowl) |
-| Differential | Hub Samples + Core 默认集成 | 对 old/new 文件生成差分，并在更新阶段应用 | [GeneralUpdate.Differential](../doc/GeneralUpdate.Differential) |
+## 更新流程总览
 
-## Step 1：准备仓库和运行环境
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                     GeneralUpdate 完整更新流程                        │
+└──────────────────────────────────────────────────────────────────────┘
 
-克隆 Samples 仓库，并确认本机可以执行 `dotnet`：
-
-```powershell
-git clone https://github.com/GeneralLibrary/GeneralUpdate-Samples.git
-cd GeneralUpdate-Samples
-dotnet --info
+  ① 版本检查               ② 下载包               ③ 应用更新
+  ┌──────────┐           ┌──────────┐           ┌──────────┐
+  │  Client  │──POST──→  │  Server  │           │ Upgrade  │
+  │ (主程序)  │←─JSON───  │ (更新服务)│           │ (升级进程) │
+  └────┬─────┘           └────┬─────┘           └────┬─────┘
+       │                      │                      │
+       │  POST /Verification  │                      │
+       │  {version, platform} │                      │
+       │ ────────────────────→│                      │
+       │                      │                      │
+       │  [{version, url,     │                      │
+       │    hash, size}]      │                      │
+       │ ←────────────────────│                      │
+       │                      │                      │
+       │  GET /File/Download  │                      │
+       │ ────────────────────→│                      │
+       │                      │                      │
+       │  .zip packages       │                      │
+       │ ←────────────────────│                      │
+       │                      │                      │
+       │  [写入 IPC 加密契约]   │                      │
+       │  [启动 Upgrade.exe]   │                      │
+       │ ────────────────────────────────────────────→│
+       │                      │                      │
+       │                      │    [读取 IPC 数据]    │
+       │                      │    [校验 Hash]        │
+       │                      │    [解压 → 覆盖]      │
+       │                      │    [启动新版本 Client] │
+       │                      │                      │
+       │ ←────────────────────────────────────────────│
+       │  [新版本运行中 ✓]     │                      │
+       │                      │                      │
 ```
 
-当前 Samples Hub 面向 `net10.0`，需要安装 [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)。
+| 角色 | 在项目中的位置 | 负责什么 |
+| --- | --- | --- |
+| Client | `MyApp.exe`（你自己的主程序） | 检查更新 → 下载包 → 启动 Upgrade |
+| Upgrade | `MyApp.Upgrade.exe`（独立的升级进程） | 校验 Hash → 解压覆盖 → 启动新版 Client |
+| Server | `GeneralUpdate-Samples/src/Server` | 返回版本信息、接收更新报告、提供补丁下载 |
+| Tools | GeneralUpdate.Tools | 生成 `generalupdate.manifest.json`，串联 Client 与 Upgrade |
 
-**预期结果**：`dotnet --info` 能输出 .NET 10 SDK 信息，`src` 目录下能看到 `Hub`、`Server`、`ImDiskDriver`、`content_client`、`content_upgrade`、`gen_packages.ps1`、`Run.cmd`、`Run.ps1` 等。
+---
 
-## Step 2：先跑通内置更新样例
+## Phase 1：环境准备
 
-### 2.1 首次运行 — 编译本地组件 DLL
+### 安装清单
 
-从源码克隆下来后，`src\Hub\libs\` 目录下包含预编译的 DLL 文件。如果你修改了 GeneralUpdate 组件的源码，可以重新编译并复制 DLL：
+| 项 | 要求 | 验证命令 |
+| --- | --- | --- |
+| .NET SDK | 8.0+（推荐 10.0） | `dotnet --version` |
+| Git | 任意版本 | `git --version` |
 
-```powershell
-cd src
-.\Run.ps1 -BuildLibs
+### 新建项目
+
+打开终端，创建 Client 和 Upgrade 两个控制台项目：
+
+```bash
+dotnet new console -n MyApp
+dotnet new console -n MyApp.Upgrade
+
+cd MyApp
+dotnet add package GeneralUpdate.Core
+
+cd ../MyApp.Upgrade
+dotnet add package GeneralUpdate.Core
 ```
 
-`-BuildLibs` 会自动查找同级目录 `..\GeneralUpdate\src\c#` 下的源码，依次编译 `GeneralUpdate.Differential`、`GeneralUpdate.Core`、`GeneralUpdate.Bowl`、`GeneralUpdate.Extension`、`GeneralUpdate.Drivelution`，并将 DLL 复制到 `src\Hub\libs\`。
+**预期结果**：两个项目目录下都有 `GeneralUpdate.Core` 的 NuGet 引用。
 
-如果只想快速体验（无需编译源码，使用预置 DLL），直接运行即可：
+---
 
-```powershell
-cd src
-.\Run.cmd
-```
+## Phase 2：集成 Client 代码
 
-或使用 PowerShell：
-
-```powershell
-cd src
-.\Run.ps1
-```
-
-### 2.2 示例菜单
-
-启动后会看到交互式菜单：
-
-```text
-  ╔══════════════════════════════════════╗
-  ║    GeneralUpdate 示例浏览器          ║
-  ╚══════════════════════════════════════╝
-
-  配置: http://localhost:5000
-
-  ═══════════════════════════════════
-    1. 完整更新 — 版本发现→下载→应用
-    2. OSS 更新
-    3. 静默更新
-    4. 推送更新
-    5. 差分算法
-    6. 压缩演示
-    7. 扩展管理
-    8. Bowl 进程守护
-    9. ImDisk 快速安装
-  ───────────────────────────────────
-    0. 退出 (Exit)
-  ═══════════════════════════════════
-```
-
-### 2.3 运行第一个样例
-
-输入 `1` 并按回车，选择"完整更新"。Hub 会自动：
-
-1. **启动 Server**（如果尚未运行）— 输出 `[Server] 启动中... ✓`
-2. 在 `mock_app` 目录创建模拟的 v1.0.0.0 应用文件
-3. 通过 `GeneralUpdateBootstrap` 向 `http://localhost:5000/Upgrade/Verification` 请求更新
-4. 下载新版本包并应用更新
-5. 打印更新后的文件列表
-
-**预期结果**：
-
-- Server 控制台显示 `GeneralUpdate Sample Upgrade Server`，监听 `http://localhost:5000/`
-- Hub 控制台显示版本发现、下载进度、更新完成信息
-- `mock_app` 目录中的文件从 v1.0.0.0 更新到 v2.0.0.0
-
-## Step 3：看懂 Server 返回了什么
-
-Hub 中每个 Sample 通过 `appsettings.json` 统一配置，再由各 Sample 的代码设置更新参数。查看 [src\Hub\appsettings.json](https://github.com/GeneralLibrary/GeneralUpdate-Samples/blob/main/src/Hub/appsettings.json)：
-
-```json
-{
-  "ServerUrl": "http://localhost:5000",
-  "AppSecretKey": "dfeb5833-975e-4afb-88f1-6278ee9aeff6",
-  "ProductId": "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
-  "ClientVersion": "1.0.0.0",
-  "UpgradeClientVersion": "1.0.0.0",
-  "MainAppName": "Hub.exe",
-  "UpgradeAppName": "Hub.exe"
-}
-```
-
-"完整更新"样例中 [CompleteUpdateSample.cs](https://github.com/GeneralLibrary/GeneralUpdate-Samples/blob/main/src/Hub/Samples/CompleteUpdateSample.cs) 使用 `UpdateRequest` 设置更新参数：
+> **在 `MyApp/Program.cs` 中粘贴以下全部内容。Client 负责：检查更新 → 下载包 → 启动 Upgrade。**
 
 ```csharp
+using GeneralUpdate.Core;
+using GeneralUpdate.Core.Configuration;
+using GeneralUpdate.Core.Event;
+
+// ================================================================
+// Client — 主程序入口，负责检测和下载更新
+// ================================================================
+
+// 只需设置 3 个 secret。MainAppName、ClientVersion、UpdateAppName
+// 等身份字段由框架自动从 generalupdate.manifest.json 发现，无需手写。
 var request = new UpdateRequest
 {
-    UpdateUrl = $"{config.ServerUrl}/Upgrade/Verification",
-    ReportUrl = $"{config.ServerUrl}/Upgrade/Report",
-    AppSecretKey = config.AppSecretKey,
-    InstallPath = mockAppDir,
-    ClientVersion = config.ClientVersion,
-    MainAppName = config.MainAppName,
-    UpdateAppName = config.UpgradeAppName,
-    ProductId = config.ProductId
+    UpdateUrl    = "http://localhost:5000/Upgrade/Verification",
+    ReportUrl    = "http://localhost:5000/Upgrade/Report",
+    AppSecretKey = "dfeb5833-975e-4afb-88f1-6278ee9aeff6",
 };
-```
 
-Server 的 `POST /Upgrade/Verification` 会读取客户端版本、AppType、Platform、ProductId 和 UpgradeMode，然后从 `versions.json` 里筛选更高版本。返回结果包含 `RecordId`、`Name`、`Hash`、`Url`、`Version`、`AppType`、`Platform`、`Format`、`Size` 等字段。
-
-**预期结果**：当 Client 当前版本是 `1.0.0.0`，而 `versions.json` 里存在 `2.0.0.0` 包时，Client 会收到可更新版本。
-
-## Step 4：理解 GeneralUpdateBootstrap 的流程
-
-每个 Sample 的核心都是一个 `GeneralUpdateBootstrap` 实例。以"完整更新"为例：
-
-```csharp
-var bootstrap = new GeneralUpdateBootstrap()
+await new GeneralUpdateBootstrap()
     .SetConfig(request)
     .SetOption(Option.AppType, AppType.Client)
-    .AddListenerUpdateInfo((_, e) => { /* 处理版本信息 */ })
-    .AddListenerMultiDownloadStatistics((_, e) => { /* 处理下载进度 */ })
-    .AddListenerException((_, e) => { /* 处理异常 */ });
-
-await bootstrap.LaunchAsync();
+    .AddListenerUpdateInfo((_, e) =>
+    {
+        Console.WriteLine($"发现 {e.Info?.Body?.Count ?? 0} 个可用更新");
+        if (e.Info?.Body != null)
+        {
+            foreach (var v in e.Info.Body)
+                Console.WriteLine($"  v{v.Version} — {v.Name} ({v.Size} bytes)");
+        }
+    })
+    .AddListenerMultiDownloadStatistics((_, e) =>
+    {
+        Console.WriteLine($"\r下载: {e.ProgressPercentage:F0}% {e.Speed}");
+    })
+    .AddListenerMultiDownloadCompleted((_, e) =>
+    {
+        Console.WriteLine();
+        Console.WriteLine($"下载 {(e.IsCompleted ? "✓ 完成" : "✗ 失败")}");
+    })
+    .AddListenerException((_, e) =>
+    {
+        Console.WriteLine($"异常: {e.Exception.Message}");
+    })
+    .LaunchAsync();
 ```
 
-`GeneralUpdate.Core` 统一了原来的 `GeneralUpdate.ClientCore` 和 `GeneralUpdate.Common`，现在只需要引用一个 NuGet 包即可获得全部能力：
+### 为什么只设 3 个参数？
 
-- **客户端更新管理**：版本检查、更新包下载、完整性验证、拉起升级程序
-- **升级执行引擎**：独立进程升级、文件替换、差分包应用、驱动安装
-- **公共基础设施**：生命周期追踪、下载引擎、序列化等底层能力
+`ClientStrategy` 在执行时会自动调用 `AppMetadataDiscoverer.Discover()`，从 `generalupdate.manifest.json`（Phase 4 用 Tools 生成）中读取身份字段并补全 `UpdateRequest`：
 
-**预期结果**：`LaunchAsync()` 执行完成后，目标目录的文件已被更新到新版本。
+| 字段 | 谁负责 | 说明 |
+| --- | --- | --- |
+| `UpdateUrl` | **你写代码** | Server 验证接口地址 |
+| `ReportUrl` | **你写代码** | Server 报告接口地址 |
+| `AppSecretKey` | **你写代码** | 应用密钥 |
+| `MainAppName` | **框架自动发现** | 从 manifest 读取 |
+| `ClientVersion` | **框架自动发现** | 从 manifest 读取 |
+| `UpdateAppName` | **框架自动发现** | 从 manifest 读取 |
+| `ProductId` | **框架自动发现** | 从 manifest 读取 |
+| `UpdatePath` | **框架自动发现** | 从 manifest 读取 |
+| `InstallPath` | **默认值** | `AppDomain.CurrentDomain.BaseDirectory` |
 
-## Step 5：用 Tools 生成自己的补丁包
+如果你不想写 `UpdateRequest`，还可以用更简短的 `SetSource()`：
 
-当你已经有两个发布目录时，可以用 GeneralUpdate.Tools 的 Patch 页面生成补丁：
-
-| Tools 字段 | 应该选择什么 |
-| --- | --- |
-| Old Directory | 用户当前安装的旧版本目录，例如 `publish\v1.0.0` |
-| New Directory | 你准备发布的新版本目录，例如 `publish\v2.0.0` |
-| Package Name | 建议包含版本，例如 `client_1.0.0_to_2.0.0` |
-| Version | 目标版本，例如 `2.0.0` |
-| Output Directory | 保存补丁 ZIP 的目录 |
-
-Samples 仓库也提供了 `gen_packages.ps1` 脚本用于快速生成测试包：
-
-```powershell
-cd src
-.\gen_packages.ps1
+```csharp
+await new GeneralUpdateBootstrap()
+    .SetSource("http://localhost:5000/Upgrade/Verification",
+               "dfeb5833-975e-4afb-88f1-6278ee9aeff6",
+               "http://localhost:5000/Upgrade/Report")
+    .SetOption(Option.AppType, AppType.Client)
+    // ... listeners
+    .LaunchAsync();
 ```
 
-该脚本使用 `src\content_client\v1.0.0.0\` 和 `src\content_client\v2.0.0.0\` 的内容生成测试补丁包，输出到 `src\Server\wwwroot\packages\`。
+Client 不直接应用更新——下载完成后写 IPC 加密契约 → 启动 Upgrade → 自身退出。
 
-Tools 会调用 Core 差分管线：旧文件和新文件不同则生成 `.patch`，新文件直接复制，删除的文件写入 `generalupdate.delete.json`，最后压缩为 ZIP。
+---
 
-**预期结果**：输出目录出现更新包 ZIP 文件，Server 的 `versions.json` 被更新。
+## Phase 3：集成 Upgrade 代码
 
-## Step 6：发布补丁包给 Server
+> **在 `MyApp.Upgrade/Program.cs` 中粘贴以下全部内容。Upgrade 比 Client 更简单——不需要 `SetConfig()`，所有参数通过加密 IPC 文件从 Client 传入。**
 
-Samples Server 默认从这里读取包：
+```csharp
+using GeneralUpdate.Core;
+using GeneralUpdate.Core.Configuration;
+using GeneralUpdate.Core.Event;
 
-```text
-src\Server\wwwroot\packages\
+// ================================================================
+// Upgrade — 独立的升级进程 (MyApp.Upgrade.exe)
+// 无需 SetConfig()，参数由 Client 通过加密 IPC 文件传入
+// ================================================================
+
+await new GeneralUpdateBootstrap()
+    .SetOption(Option.AppType, AppType.Upgrade)
+    .AddListenerMultiDownloadStatistics((_, e) =>
+    {
+        Console.WriteLine($"\r应用补丁: {e.ProgressPercentage:F0}%");
+    })
+    .AddListenerMultiDownloadCompleted((_, e) =>
+    {
+        Console.WriteLine();
+        Console.WriteLine($"补丁 {(e.IsCompleted ? "✓ 完成" : "✗ 失败")}");
+    })
+    .AddListenerException((_, e) =>
+    {
+        Console.WriteLine($"异常: {e.Exception.Message}");
+    })
+    .LaunchAsync();
 ```
 
-你需要把补丁 ZIP 放到该目录，并确保同目录下的 `versions.json` 包含对应记录。一条版本记录至少要让 Server 能匹配和下载：
+### Client vs Upgrade 差异
+
+| | Client | Upgrade |
+| --- | --- | --- |
+| `AppType` | `AppType.Client` | `AppType.Upgrade` |
+| `SetConfig()` | ✅ 必须，设置服务器地址、版本等 | ❌ 不需要，通过 IPC 从 Client 获取 |
+| 职责 | 检查版本 → 下载包 → 启动 Upgrade | Hash 校验 → 解压覆盖 → 启动新版 Client |
+| 谁启动谁 | 由用户直接启动 | 由 Client 进程自动启动 |
+
+---
+
+## Phase 4：使用 Tools 生成项目结构
+
+> **Client 和 Upgrade 代码写好后，用 Tools 的配置生成器（Config 标签页）一键 `dotnet publish` 并生成 `generalupdate.manifest.json`。**
+
+### 操作步骤
+
+打开 **GeneralUpdate.Tools** → 切换到 **Config** 标签页（配置生成器）：
+
+1. **Client .csproj Path**：点击 Browse，选择 `MyApp.csproj`
+2. **Upgrade .csproj Path**：点击 Browse，选择 `MyApp.Upgrade.csproj`
+3. 点击 **Analyze**：Tools 解析两个 .csproj，自动填入：
+   - `MainAppName`：来自 Client 项目的 AssemblyName（如 `MyApp.exe`）
+   - `UpdateAppName`：来自 Upgrade 项目的 AssemblyName（如 `MyApp.Upgrade.exe`）
+   - `ClientVersion` / `UpgradeClientVersion`：默认 `1.0.0`，按需修改
+4. 检查自动填入的字段，确认 `UpdatePath` 为 `update/`（默认值）
+5. 点击 **Generate Sample**：Tools 依次执行：
+   - `dotnet publish` Client → 输出到根目录
+   - `dotnet publish` Upgrade → 输出到 `update/` 子目录
+   - 写入 `generalupdate.manifest.json` 到根目录
+
+### 发布后的目录结构
+
+Tools 可以帮助你一键 `dotnet publish` 并组装输出目录（通过 Config 标签页的 Sample Publisher）。最终结构如下：
+
+```
+publish/
+├── MyApp.exe                   # Client publish 产物（Phase 2）
+├── MyApp.dll
+├── GeneralUpdate.Core.dll
+├── generalupdate.manifest.json # Tools 生成，放根目录，框架自动发现
+└── update/                     # Upgrade publish 产物（Phase 3），子目录名来自 manifest 的 updatePath
+    ├── MyApp.Upgrade.exe
+    └── MyApp.Upgrade.dll
+```
+
+> **注意**：`MyApp.Upgrade.exe` 不在根目录，而是在 `update/` 子目录下。框架根据 manifest 的 `updatePath` 字段（默认 `"update/"`）找到并启动它。
+
+### `generalupdate.manifest.json` 示例
 
 ```json
 {
-  "PacketName": "client_1.0.0_to_2.0.0",
-  "Hash": "补丁ZIP的sha256",
-  "Version": "2.0.0.0",
-  "Url": "http://localhost:5000/File/Download/补丁ZIP的sha256",
-  "AppType": 1,
-  "Platform": 1,
-  "ProductId": "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
-  "Format": ".zip",
-  "IsCrossVersion": true,
-  "FromVersion": "1.0.0.0",
-  "ToVersion": "2.0.0.0"
+  "mainAppName": "MyApp.exe",
+  "clientVersion": "1.0.0.0",
+  "updateAppName": "MyApp.Upgrade.exe",
+  "upgradeClientVersion": "1.0.0.0",
+  "appType": "Client",
+  "productId": "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
+  "updatePath": "update/"
 }
 ```
 
-Hash 可以用 Tools 的 OSS 页面计算，也可以在 CI 中计算。Server 下载接口是 `GET /File/Download/{hash}`，支持 HTTP Range，便于断点续传。
+> **注意：manifest 只存身份/结构信息，不存 secret。** `UpdateUrl`、`ReportUrl`、`AppSecretKey` 等敏感字段始终写在代码里，由 Phase 2 的 `request.XXX = "..."` 提供。
 
-**预期结果**：重启 Hub 后运行样例，Server 启动横幅会列出加载到的版本；请求时能拿到你刚发布的版本记录。
+---
 
-## Step 7：探索其他内置样例
+## Phase 5：启动 Server
 
-Hub 提供了 9 个内置样例，覆盖了 GeneralUpdate 的主要使用场景：
+> **Client / Upgrade / manifest 全部就绪，启动 Server 准备端到端验证。**
 
-| 编号 | 样例 | 说明 |
+```bash
+git clone https://github.com/GeneralLibrary/GeneralUpdate-Samples.git
+cd GeneralUpdate-Samples/src/Server
+dotnet run
+```
+
+预期输出：
+
+```
+╔══════════════════════════════════════════════════╗
+║     GeneralUpdate Sample Upgrade Server          ║
+╠══════════════════════════════════════════════════╣
+║  Verification: http://localhost:5000/Upgrade/Verification
+║  Report:       http://localhost:5000/Upgrade/Report
+║  Download:     http://localhost:5000/File/Download/{hash}
+║  Packages:     N version(s) loaded
+╚══════════════════════════════════════════════════╝
+```
+
+### Server 三端点速查
+
+| 端点 | 方法 | 用途 |
 | --- | --- | --- |
-| 1 | 完整更新 | 标准更新闭环：版本发现→下载→应用 |
-| 2 | OSS 更新 | 基于对象存储的更新模式 |
-| 3 | 静默更新 | 后台下载，用户无感知 |
-| 4 | 推送更新 | 基于 SignalR 的推送实时更新 |
-| 5 | 差分算法 | 二进制差分 Clean/Dirty 演示 |
-| 6 | 压缩演示 | 压缩中间件演示 |
-| 7 | 扩展管理 | 插件/扩展的查询、下载、安装 |
-| 8 | Bowl 进程守护 | 进程崩溃监控与 Dump 收集 |
-| 9 | ImDisk 快速安装 | 驱动级快速安装演示 |
+| `/Upgrade/Verification` | POST | Client 上报当前版本 → Server 返回可用更新列表 |
+| `/Upgrade/Report` | POST | Client 上报更新结果（成功 / 失败） |
+| `/File/Download/{hash}` | GET | 下载更新包（支持 HTTP Range 断点续传） |
 
-建议依次运行每个样例，观察它们在 `mock_app` 目录中的操作结果。
+Server 读取 `wwwroot/packages/versions.json` 中的包元数据并对外提供下载。
 
-**预期结果**：每个样例运行后，控制台会明确显示该场景的关键步骤和结果。
+**快速验证**：
+
+```bash
+curl -X POST http://localhost:5000/Upgrade/Verification \
+  -H "Content-Type: application/json" \
+  -d '{"Version":"1.0.0.0"}'
+```
+
+应返回包含可用更新版本的 JSON 响应。
+
+---
+
+## Phase 6：端到端运行验证
+
+```
+# 终端 1 — 确保 Server 在运行
+cd GeneralUpdate-Samples/src/Server && dotnet run
+
+# 终端 2 — 运行 Client
+cd MyApp && dotnet run
+```
+
+### 完整预期输出
+
+```
+Client:
+  [UpdateInfo] 发现 1 个可用更新
+    v2.0.0.0 — client_1.0.0_to_2.0.0 (xxxxx bytes)
+  下载: 45% 1.2MB/s
+  下载: 100%
+  下载 ✓ 完成
+  → 启动 MyApp.Upgrade.exe...
+
+Upgrade:
+  应用补丁: 50%
+  应用补丁: 100%
+  补丁 ✓ 完成
+  → 启动 MyApp.exe (新版本)...
+
+Client (新版本):
+  MyApp v2.0.0.0 ✓
+```
+
+### 排查清单
+
+| 现象 | 检查 |
+| --- | --- |
+| Client 连不上 Server | `curl http://localhost:5000/Upgrade/Verification` 确认 Server 在跑 |
+| 返回"Already up to date" | `versions.json` 中是否有比 `ClientVersion` 更高的版本 |
+| 下载完成但未启动 Upgrade | `MyApp.Upgrade.exe` 是否在 `update/` 子目录下，manifest 的 `updatePath` 是否正确 |
+| Upgrade 报错退出 | 检查目录写入权限、杀毒软件是否拦截 |
+| 端口被占用 | 修改 Server 启动参数 `--Urls http://0.0.0.0:5001`，同步修改 Client 的 `UpdateUrl` |
+
+---
 
 ## 下一步
 
-跑通这条链路后，建议按顺序阅读：
+跑通这条闭环后，建议按顺序深入阅读：
 
-1. [GeneralUpdate.Core](../doc/GeneralUpdate.Core)：更新策略、事件通知、静默更新、manifest 极简配置。
-2. [GeneralUpdate.Tools](./GeneralUpdate.PacketTool)：补丁包、Hash、OSS Config、Simulation。
-3. [GeneralUpdate.Differential](../doc/GeneralUpdate.Differential)：差分算法、并行处理和 Clean/Dirty。
-4. [GeneralUpdate.Bowl](../doc/GeneralUpdate.Bowl)：崩溃监控、备份和失败恢复。
-5. [GeneralUpdate.Tools](./GeneralUpdate.PacketTool)：补丁包、Hash、OSS Config、Simulation。
+1. [GeneralUpdate.Core](../doc/GeneralUpdate.Core)：更新策略、事件通知、静默更新、manifest 极简配置
+2. [GeneralUpdate.Differential](../doc/GeneralUpdate.Differential)：差分算法、并行处理和 Clean/Dirty
+3. [GeneralUpdate.Bowl](../doc/GeneralUpdate.Bowl)：崩溃监控、备份和失败恢复
+4. [GeneralUpdate.Tools](./GeneralUpdate.PacketTool)：补丁包、Hash、OSS Config、Simulation 的完整操作指南
 
-## Sample UI
+## 示例仓库
 
-示例程序界面预览：
-
-![](imgs\sampleclient.png)
-
-![](imgs\sampleupgrade.png)
-
-| 仓库地址 |
-| --- |
-| [ClientSample.sln](https://github.com/GeneralLibrary/GeneralUpdate-Samples/blob/main/src/Client/ClientSample.sln) |
-| [UpgradeSample.sln](https://github.com/GeneralLibrary/GeneralUpdate-Samples/blob/main/src/Upgrade/UpgradeSample.sln) |
+| 仓库 | 地址 |
+| --- | --- |
+| Samples（Server + Hub） | [GeneralUpdate-Samples](https://github.com/GeneralLibrary/GeneralUpdate-Samples) |
+| Tools（GUI 配置工具） | [GeneralUpdate.Tools](https://github.com/Juster/GeneralUpdate.Tools) |
+| Core（NuGet 包源码） | [GeneralUpdate](https://github.com/GeneralLibrary/GeneralUpdate) |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quickstart/Beginner cookbook.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/quickstart/Beginner cookbook.md
@@ -29,7 +29,7 @@ title: 入门实战手册
   │ (主程序)  │←─JSON───  │ (更新服务)│           │ (升级进程) │
   └────┬─────┘           └────┬─────┘           └────┬─────┘
        │                      │                      │
-       │  POST /Verification  │                      │
+       │  POST /Upgrade/Verification               │                      │
        │  {version, platform} │                      │
        │ ────────────────────→│                      │
        │                      │                      │
@@ -354,7 +354,7 @@ Client (新版本):
 
 | 现象 | 检查 |
 | --- | --- |
-| Client 连不上 Server | `curl http://localhost:5000/Upgrade/Verification` 确认 Server 在跑 |
+| Client 连不上 Server | `curl -X POST http://localhost:5000/Upgrade/Verification` 确认 Server 在跑 |
 | 返回"Already up to date" | `versions.json` 中是否有比 `ClientVersion` 更高的版本 |
 | 下载完成但未启动 Upgrade | `MyApp.Upgrade.exe` 是否在 `update/` 子目录下，manifest 的 `updatePath` 是否正确 |
 | Upgrade 报错退出 | 检查目录写入权限、杀毒软件是否拦截 |


### PR DESCRIPTION
Closes #92

## Summary

Rewrites the Beginner cookbook from a Hub-centric "run the samples" approach into a self-guided "write your own" tutorial that walks first-time users through building a complete update pipeline from scratch.

## Changes

- **Phase 0**: Add bilibili video embed (BV12P9dBiEEh) and ASCII update flow diagram at page top
- **Phase 1**: Environment setup (dotnet new + NuGet)
- **Phase 2**: Client code — only 3 secrets in `UpdateRequest`; identity fields auto-discovered by `AppMetadataDiscoverer` from `generalupdate.manifest.json`
- **Phase 3**: Upgrade code — `AppType.Upgrade`, no `SetConfig()`, params via encrypted IPC
- **Phase 4**: Tools Config tab — .csproj path → Analyze → Generate Sample (not Patch tab)
- **Phase 5**: Start Sample Server
- **Phase 6**: End-to-end verification with troubleshooting checklist

## Fixes vs original

| Issue | Fix |
|---|---|
| Hub-centric flow required understanding the sample browser | Self-guided: user writes their own Client/Upgrade |
| Client code manually set 6-9 fields redundant with manifest | Only 3 secrets; framework auto-discovers the rest |
| Tools instructions pointed to Patch tab (wrong) | Points to Config tab with correct field names |
| Directory structure showed Upgrade.exe at root | Upgrade.exe in `update/` subdirectory per `updatePath` |
| Manifest JSON showed secrets (`UpdateUrl`, etc.) | Shows identity-only fields matching `ManifestInfo` |

## Files changed

- `website/docs/quickstart/Beginner cookbook.md` (zh default)
- `website/i18n/zh-Hans/.../Beginner cookbook.md` (zh-Hans)
- `website/i18n/en/.../Beginner cookbook.md` (English)

🤖 Generated with [Claude Code](https://claude.com/claude-code)