### PR TITLE
fix: 调整文档右侧TOC导航栏，避免遮挡主要内容

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -602,6 +602,31 @@
    TOC  (right sidebar)
    ════════════════════════════════════════════════════════════════ */
 
+/* ── Push TOC further right, give main content more room ── */
+@media (min-width: 997px) {
+  /* Widen content column from 75% → 80% */
+  [class*="docMainContainer"] [class*="docItemCol"] {
+    max-width: 80% !important;
+  }
+
+  /* Narrow TOC column from 25% → 20% */
+  [class*="docMainContainer"] .col--3 {
+    --ifm-col-width: calc(20%);
+  }
+
+  /* Prevent wide content (tables, code) from bleeding into TOC */
+  [class*="docItemCol"] .markdown {
+    overflow-x: auto;
+  }
+
+  /* Visual separation between content and TOC */
+  .table-of-contents {
+    padding-left: 1rem;
+    margin-left: 0.25rem;
+    border-left: 1px solid var(--ifm-color-emphasis-200);
+  }
+}
+
 .table-of-contents__link {
   font-size: 0.85rem;
   transition: color 0.15s;


### PR DESCRIPTION
## 改动说明

本次 PR 修复了文档站点右侧 TOC 导航栏容易遮挡主要内容的问题。

### 具体修改

| 属性 | 修改前 | 修改后 |
|---|---|---|
| 主内容列宽度 | 75% (855px) | **80% (912px)** |
| TOC 列宽度 | 25% (285px) | **20% (228px)** |
| 内容溢出保护 | 无 | `overflow-x: auto` |
| TOC 视觉分隔 | 无 | 左边框 + 内边距 |

### 效果

- 主内容多获得 ~57px 水平空间
- TOC 被推至更右侧，减少与内容的视觉重叠
- 宽表格/代码块超出时会显示横向滚动条而非覆盖 TOC
- 所有改动仅在桌面端生效（≥997px），移动端不受影响

### 修改文件

- [x] `website/src/css/custom.css` — 在 TOC 区块添加 `@media (min-width: 997px)` 布局覆盖

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)