### PR TITLE
feat: add Corporate Wall, OSS Partners, Outsourcing, and Paid Consulting pages

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -90,11 +90,29 @@ const config = {
                 docId: 'doc/GeneralSpacestation',
                 label: 'GeneralSpacestation',
               },
+              {
+                to: '/outsourcing',
+                label: '软件外包服务',
+              },
+              {
+                to: '/paid-consulting',
+                label: '付费咨询',
+              },
             ],
           },
           {
             to: '/contact',
             label: '联系方式',
+            position: 'right',
+          },
+          {
+            to: '/corporate-wall',
+            label: '企业墙',
+            position: 'right',
+          },
+          {
+            to: '/oss-partners',
+            label: '开源生态伙伴',
             position: 'right',
           },
           {

--- a/website/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/en/docusaurus-theme-classic/navbar.json
@@ -26,5 +26,21 @@
   "item.label.GeneralSpacestation": {
     "message": "GeneralSpacestation",
     "description": "Navbar item with label GeneralSpacestation"
+  },
+  "item.label.软件外包服务": {
+    "message": "Software Outsourcing",
+    "description": "Navbar item with label 软件外包服务"
+  },
+  "item.label.企业墙": {
+    "message": "Corporate Wall",
+    "description": "Navbar item with label 企业墙"
+  },
+  "item.label.开源生态伙伴": {
+    "message": "OSS Partners",
+    "description": "Navbar item with label 开源生态伙伴"
+  },
+  "item.label.付费咨询": {
+    "message": "Paid Consultation",
+    "description": "Navbar item with label 付费咨询"
   }
 }

--- a/website/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
@@ -26,5 +26,21 @@
   "item.label.GeneralSpacestation": {
     "message": "GeneralSpacestation",
     "description": "Navbar item with label GeneralSpacestation"
+  },
+  "item.label.软件外包服务": {
+    "message": "软件外包服务",
+    "description": "Navbar item with label 软件外包服务"
+  },
+  "item.label.企业墙": {
+    "message": "企业墙",
+    "description": "Navbar item with label 企业墙"
+  },
+  "item.label.开源生态伙伴": {
+    "message": "开源生态伙伴",
+    "description": "Navbar item with label 开源生态伙伴"
+  },
+  "item.label.付费咨询": {
+    "message": "付费咨询",
+    "description": "Navbar item with label 付费咨询"
   }
 }

--- a/website/src/pages/contact.js
+++ b/website/src/pages/contact.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Layout from '@theme/Layout';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Heading from '@theme/Heading';
+import contactImg from '@site/docs/doc/imgs/contact.png';
 
 export default function Contact() {
   const {i18n} = useDocusaurusContext();
@@ -23,6 +24,23 @@ export default function Contact() {
         </p>
 
         <div style={{display: 'flex', flexDirection: 'column', gap: '2rem'}}>
+
+          {/* ── 联系方式 ── */}
+          <div style={{
+            border: '1px solid var(--ifm-color-emphasis-300)',
+            borderRadius: '8px',
+            padding: '1.5rem',
+          }}>
+            <Heading as="h3">{isEn ? 'Contact' : '联系方式'}</Heading>
+            <p style={{color: 'var(--ifm-color-secondary-darkest)', marginBottom: '1rem'}}>
+              {isEn
+                ? 'Scan the QR code below to contact us.'
+                : '扫描下方二维码联系我们。'}
+            </p>
+            <div style={{textAlign: 'center'}}>
+              <img src={contactImg} alt={isEn ? 'Contact QR Code' : '联系方式二维码'} style={{maxWidth: '100%', borderRadius: '8px'}} />
+            </div>
+          </div>
 
           {/* ── QQ 群 ── */}
           <div style={{
@@ -52,57 +70,6 @@ export default function Contact() {
             </p>
           </div>
 
-          {/* ── GitHub Issues ── */}
-          <div style={{
-            border: '1px solid var(--ifm-color-emphasis-300)',
-            borderRadius: '8px',
-            padding: '1.5rem',
-          }}>
-            <Heading as="h3">GitHub Issues</Heading>
-            <p style={{margin: 0}}>
-              <a href="https://github.com/GeneralLibrary/GeneralUpdate/issues" target="_blank" rel="noopener">
-                github.com/GeneralLibrary/GeneralUpdate/issues
-              </a>
-            </p>
-            <p style={{color: 'var(--ifm-color-secondary-darkest)', marginTop: '0.5rem'}}>
-              {isEn
-                ? 'Submit bug reports, feature requests, or ask questions on GitHub. Issues are publicly visible and help everyone.'
-                : '提交 Bug 报告、功能建议或问题答疑。Issue 公开可见，帮助所有人。'}
-            </p>
-          </div>
-
-          {/* ── Email ── */}
-          <div style={{
-            border: '1px solid var(--ifm-color-emphasis-300)',
-            borderRadius: '8px',
-            padding: '1.5rem',
-          }}>
-            <Heading as="h3">{isEn ? 'Email' : '邮箱'}</Heading>
-            <p style={{margin: 0}}>
-              <a href="mailto:zhuzhen723723@outlook.com">zhuzhen723723@outlook.com</a>
-            </p>
-            <p style={{color: 'var(--ifm-color-secondary-darkest)', marginTop: '0.5rem'}}>
-              {isEn
-                ? 'For business inquiries, private questions, or one-on-one paid consultations.'
-                : '商务合作、私密问题或一对一付费咨询。'}
-            </p>
-          </div>
-
-          {/* ── 付费咨询 ── */}
-          <div style={{
-            border: '1px solid var(--ifm-color-emphasis-300)',
-            borderRadius: '8px',
-            padding: '1.5rem',
-            background: 'var(--ifm-color-warning-contrast-background)',
-          }}>
-            <Heading as="h3">{isEn ? 'Paid Consultation' : '付费咨询'}</Heading>
-            <p style={{margin: 0, color: 'var(--ifm-color-secondary-darkest)'}}>
-              {isEn
-                ? 'Due to the large number of individual communications, the author\'s time and energy are limited. One-on-one technical support and customized secondary development require paid consultation. Please state your purpose when adding (WeChat recommended, idle chats are refused).'
-                : '由于单独沟通人数过多作者时间精力有限，一对一技术支持和定制化二次开发需付费咨询。加好友请注明来意（推荐微信，拒绝闲聊）。'}
-            </p>
-          </div>
-
           {/* ── 企业墙 ── */}
           <div style={{
             border: '1px solid var(--ifm-color-emphasis-300)',
@@ -114,25 +81,6 @@ export default function Contact() {
               {isEn
                 ? 'The open-source project is building a corporate wall on the official website. If your company is using GeneralUpdate in production and would like free promotion, please contact the author.'
                 : '本开源项目在官网上建立企业墙，如果有企业在项目中有使用本项目并且想上墙进行免费宣传可以联系作者。'}
-            </p>
-          </div>
-
-          {/* ── 赞助 ── */}
-          <div style={{
-            border: '1px solid var(--ifm-color-emphasis-300)',
-            borderRadius: '8px',
-            padding: '1.5rem',
-          }}>
-            <Heading as="h3">{isEn ? 'Sponsorship' : '赞助一下'}</Heading>
-            <p style={{color: 'var(--ifm-color-secondary-darkest)'}}>
-              {isEn
-                ? 'All community donations will be used for the development of open-source projects and to reward code contributors. Sponsors\' company logos will be displayed on the project website. Your sponsorship will help us improve quality, add features, and provide a better user experience.'
-                : '所有的社区捐赠将用于开源项目的发展建设和奖励代码贡献者。赞助者的公司标志将展示在项目网站上。您的赞助将帮助我们提高项目质量、增加更多功能、提供更好的用户体验。'}
-            </p>
-            <p style={{color: 'var(--ifm-color-secondary-darkest)', fontSize: '0.9rem', fontStyle: 'italic'}}>
-              {isEn
-                ? 'Code contributors: please contact the email above to claim your rewards.'
-                : '代码贡献者请联系上方邮箱领取奖励。'}
             </p>
           </div>
 

--- a/website/src/pages/corporate-wall.js
+++ b/website/src/pages/corporate-wall.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Heading from '@theme/Heading';
+import styles from './corporate-wall.module.css';
+
+function CompanyCard({ name, description, descriptionEn }) {
+  const {i18n} = useDocusaurusContext();
+  const isEn = i18n.currentLocale === 'en';
+  return (
+    <div className={styles.card}>
+      <div className={styles.cardHeader}>
+        <h3 className={styles.cardName}>{name}</h3>
+      </div>
+      <p className={styles.cardDesc}>
+        {isEn ? descriptionEn : description}
+      </p>
+    </div>
+  );
+}
+
+export default function CorporateWall() {
+  const {i18n} = useDocusaurusContext();
+  const isEn = i18n.currentLocale === 'en';
+
+  const companies = [
+    {
+      name: '天津云度科技',
+      description: '专注于云计算与数字化转型，在多条产品线中集成 GeneralUpdate 实现客户端自动更新。',
+      descriptionEn: 'Focused on cloud computing and digital transformation, integrating GeneralUpdate across multiple product lines for automatic client updates.',
+    },
+    {
+      name: '上海铱泓科技',
+      description: '致力于开源 UI 组件库研发，旗下 Semi.Avalonia 和 Ursa.Avalonia 等优秀开源项目被广泛使用。',
+      descriptionEn: 'Dedicated to open-source UI component library development, with excellent projects like Semi.Avalonia and Ursa.Avalonia widely adopted.',
+    },
+    {
+      name: '天津****化工工程有限公司',
+      description: '将 GeneralUpdate 应用于工业自动化系统的客户端升级管理。',
+      descriptionEn: 'Using GeneralUpdate for client upgrade management in industrial automation systems.',
+    },
+    {
+      name: '沈阳**汽车科技有限公司',
+      description: '在车载智能终端软件更新中采用 GeneralUpdate 解决方案。',
+      descriptionEn: 'Adopting GeneralUpdate solutions for software updates in automotive intelligent terminals.',
+    },
+  ];
+
+  const title = isEn ? 'Corporate Wall' : '企业墙';
+  const description = isEn
+    ? 'Companies using GeneralUpdate in production'
+    : '在生产环境中使用 GeneralUpdate 的企业';
+
+  return (
+    <Layout title={title} description={description}>
+      <main className={styles.page}>
+        <Heading as="h1" className={styles.pageTitle}>
+          {title}
+        </Heading>
+        <p className={styles.pageSubtitle}>
+          {isEn
+            ? 'Special thanks to the following companies using GeneralUpdate in production.'
+            : '感谢以下企业在生产环境中使用 GeneralUpdate。'}
+        </p>
+        <div className={styles.cardGrid}>
+          {companies.map((c, i) => <CompanyCard key={i} {...c} />)}
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/website/src/pages/corporate-wall.module.css
+++ b/website/src/pages/corporate-wall.module.css
@@ -1,0 +1,110 @@
+/* ════════════════════════════════════════════════════════════════
+   CORPORATE WALL — Card Grid Layout
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── Page layout ── */
+.page {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.pageTitle {
+  font-size: 2.5rem;
+  font-weight: 900;
+  text-align: center;
+  margin-bottom: 1rem;
+  font-family: 'Courier New', monospace;
+  text-transform: uppercase;
+  letter-spacing: 3px;
+  color: var(--ifm-color-primary-darkest);
+}
+
+.pageSubtitle {
+  text-align: center;
+  color: var(--ifm-color-secondary-darkest);
+  margin-bottom: 3rem;
+  font-size: 1.1rem;
+}
+
+/* ── Card grid ── */
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  gap: 2rem;
+}
+
+/* ── Individual card ── */
+.card {
+  background: var(--ifm-card-background-color, #fff);
+  border: 3px solid var(--ifm-color-emphasis-300);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.08);
+  transition: all 0.3s ease;
+}
+
+.card:hover {
+  transform: translate(-4px, -4px);
+  box-shadow: 10px 10px 0 rgba(0, 0, 0, 0.12);
+  border-color: var(--ifm-color-primary);
+}
+
+/* ── Card header: company name top-left ── */
+.cardHeader {
+  margin-bottom: 0.75rem;
+}
+
+.cardName {
+  font-size: 1.3rem;
+  font-weight: 800;
+  margin: 0;
+  color: var(--ifm-color-primary-darkest);
+  font-family: 'Courier New', monospace;
+}
+
+/* ── Description ── */
+.cardDesc {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-700);
+  margin: 0;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   DARK MODE
+   ════════════════════════════════════════════════════════════════ */
+[data-theme='dark'] .card {
+  background: var(--ifm-background-surface-color);
+  border-color: rgba(93, 173, 226, 0.25);
+  box-shadow: 6px 6px 0 rgba(93, 173, 226, 0.1);
+}
+
+[data-theme='dark'] .card:hover {
+  box-shadow: 10px 10px 0 rgba(93, 173, 226, 0.2);
+  border-color: var(--ifm-color-primary);
+}
+
+[data-theme='dark'] .cardName {
+  color: var(--ifm-color-primary-lightest);
+}
+
+[data-theme='dark'] .cardDesc {
+  color: var(--ifm-color-secondary-darkest);
+}
+
+[data-theme='dark'] .pageTitle {
+  color: var(--ifm-color-primary-lightest);
+}
+
+/* ════════════════════════════════════════════════════════════════
+   RESPONSIVE
+   ════════════════════════════════════════════════════════════════ */
+@media screen and (max-width: 768px) {
+  .cardGrid {
+    grid-template-columns: 1fr;
+  }
+  .pageTitle {
+    font-size: 2rem;
+  }
+}

--- a/website/src/pages/oss-partners.js
+++ b/website/src/pages/oss-partners.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Heading from '@theme/Heading';
+import styles from './oss-partners.module.css';
+
+function PartnerCard({ name, url, description, descriptionEn }) {
+  const {i18n} = useDocusaurusContext();
+  const isEn = i18n.currentLocale === 'en';
+  return (
+    <div className={styles.card}>
+      <div className={styles.cardHeader}>
+        <h3 className={styles.cardName}>{name}</h3>
+        <a href={url} className={styles.cardLink} target="_blank" rel="noopener noreferrer">
+          {url}
+        </a>
+      </div>
+      <p className={styles.cardDesc}>
+        {isEn ? descriptionEn : description}
+      </p>
+    </div>
+  );
+}
+
+export default function OssPartners() {
+  const {i18n} = useDocusaurusContext();
+  const isEn = i18n.currentLocale === 'en';
+
+  const partners = [
+    {
+      name: 'Semi.Avalonia',
+      url: 'https://github.com/irihitech/Semi.Avalonia',
+      description: '一套 Semi Design 风格的 Avalonia UI 主题库，帮助开发者快速构建现代、美观的跨平台桌面应用。',
+      descriptionEn: 'A Semi Design-inspired Avalonia UI theme library for building modern, beautiful cross-platform desktop applications.',
+    },
+    {
+      name: 'Ursa.Avalonia',
+      url: 'https://github.com/irihitech/Ursa.Avalonia',
+      description: '一套包含丰富自定义控件的 Avalonia UI 组件库，为开发者提供开箱即用的高级 UI 组件。',
+      descriptionEn: 'A rich Avalonia UI component library with custom controls, providing developers with ready-to-use advanced UI components.',
+    },
+    {
+      name: 'WPFDevelopers',
+      url: 'https://github.com/WPFDevelopersOrg/WPFDevelopers',
+      description: '一个专注于 WPF 开发的开源项目集合，汇集了大量实用的 WPF 控件、模板和开发资源。',
+      descriptionEn: 'An open-source project collection focused on WPF development, featuring a wealth of practical WPF controls, templates, and resources.',
+    },
+    {
+      name: 'Layui-WPF',
+      url: 'https://github.com/Layui-WPF-Team/Layui-WPF',
+      description: '将经典 Layui 风格带入 WPF 的 UI 框架，让 WPF 开发者也能享受到 Layui 简洁优雅的设计语言。',
+      descriptionEn: 'A UI framework bringing the classic Layui design style to WPF, allowing WPF developers to enjoy Layui\'s clean and elegant design language.',
+    },
+    {
+      name: 'AntdUI',
+      url: 'https://github.com/AntdUI/AntdUI',
+      description: '基于 Ant Design 风格的 .NET UI 控件库，为 WinForms/WPF 桌面开发提供企业级 UI 解决方案。',
+      descriptionEn: 'A .NET UI control library based on Ant Design style, providing enterprise-grade UI solutions for WinForms and WPF desktop development.',
+    },
+    {
+      name: 'routin.ai',
+      url: 'https://routin.ai/',
+      description: '人工智能与自动化平台，通过 AI 技术赋能企业业务流程智能化升级。',
+      descriptionEn: 'An AI and automation platform that empowers enterprise business process upgrades through artificial intelligence technology.',
+    },
+    {
+      name: 'OpenCowork',
+      url: 'https://github.com/AIDotNet/OpenCowork',
+      description: '开源协同办公平台，提供团队协作、文档管理、项目管理等企业级协同功能。',
+      descriptionEn: 'An open-source collaborative office platform providing enterprise-grade collaboration features including team workspace, document management, and project management.',
+    },
+  ];
+
+  const title = isEn ? 'Open Source Partners' : '开源生态伙伴';
+  const description = isEn
+    ? 'Open source projects and communities in the .NET ecosystem'
+    : '.NET 生态中的开源项目与社区';
+
+  return (
+    <Layout title={title} description={description}>
+      <main className={styles.page}>
+        <Heading as="h1" className={styles.pageTitle}>
+          {title}
+        </Heading>
+        <p className={styles.pageSubtitle}>
+          {isEn
+            ? 'Thank you to the following open-source projects and communities for their contributions to the .NET ecosystem.'
+            : '感谢以下开源项目与社区对 .NET 生态的贡献。'}
+        </p>
+        <div className={styles.cardGrid}>
+          {partners.map((p, i) => <PartnerCard key={i} {...p} />)}
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/website/src/pages/oss-partners.module.css
+++ b/website/src/pages/oss-partners.module.css
@@ -1,0 +1,124 @@
+/* ════════════════════════════════════════════════════════════════
+   OSS PARTNERS — Card Grid Layout
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── Page layout ── */
+.page {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.pageTitle {
+  font-size: 2.5rem;
+  font-weight: 900;
+  text-align: center;
+  margin-bottom: 1rem;
+  font-family: 'Courier New', monospace;
+  text-transform: uppercase;
+  letter-spacing: 3px;
+  color: var(--ifm-color-primary-darkest);
+}
+
+.pageSubtitle {
+  text-align: center;
+  color: var(--ifm-color-secondary-darkest);
+  margin-bottom: 3rem;
+  font-size: 1.1rem;
+}
+
+/* ── Card grid ── */
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  gap: 2rem;
+}
+
+/* ── Individual card ── */
+.card {
+  background: var(--ifm-card-background-color, #fff);
+  border: 3px solid var(--ifm-color-emphasis-300);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.08);
+  transition: all 0.3s ease;
+}
+
+.card:hover {
+  transform: translate(-4px, -4px);
+  box-shadow: 10px 10px 0 rgba(0, 0, 0, 0.12);
+  border-color: var(--ifm-color-primary);
+}
+
+/* ── Card header: project name top-left + repo link ── */
+.cardHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.cardName {
+  font-size: 1.5rem;
+  font-weight: 800;
+  margin: 0;
+  color: var(--ifm-color-primary-darkest);
+  font-family: 'Courier New', monospace;
+}
+
+.cardLink {
+  font-size: 0.85rem;
+  color: var(--ifm-color-primary);
+  word-break: break-all;
+  display: inline-block;
+}
+
+.cardLink:hover {
+  text-decoration: underline;
+}
+
+/* ── Description ── */
+.cardDesc {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-700);
+  margin: 0;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   DARK MODE
+   ════════════════════════════════════════════════════════════════ */
+[data-theme='dark'] .card {
+  background: var(--ifm-background-surface-color);
+  border-color: rgba(93, 173, 226, 0.25);
+  box-shadow: 6px 6px 0 rgba(93, 173, 226, 0.1);
+}
+
+[data-theme='dark'] .card:hover {
+  box-shadow: 10px 10px 0 rgba(93, 173, 226, 0.2);
+  border-color: var(--ifm-color-primary);
+}
+
+[data-theme='dark'] .cardName {
+  color: var(--ifm-color-primary-lightest);
+}
+
+[data-theme='dark'] .cardDesc {
+  color: var(--ifm-color-secondary-darkest);
+}
+
+[data-theme='dark'] .pageTitle {
+  color: var(--ifm-color-primary-lightest);
+}
+
+/* ════════════════════════════════════════════════════════════════
+   RESPONSIVE
+   ════════════════════════════════════════════════════════════════ */
+@media screen and (max-width: 768px) {
+  .cardGrid {
+    grid-template-columns: 1fr;
+  }
+  .pageTitle {
+    font-size: 2rem;
+  }
+}

--- a/website/src/pages/outsourcing.js
+++ b/website/src/pages/outsourcing.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Heading from '@theme/Heading';
+import contactImg from '@site/docs/doc/imgs/contact.png';
+
+export default function Outsourcing() {
+  const {i18n} = useDocusaurusContext();
+  const isEn = i18n.currentLocale === 'en';
+
+  const title = isEn ? 'Software Outsourcing Services' : '软件外包服务';
+  const description = isEn
+    ? 'Professional enterprise-grade software outsourcing services'
+    : '专业的企业级软件外包服务';
+
+  return (
+    <Layout title={title} description={description}>
+      <main style={{maxWidth: 800, margin: '0 auto', padding: '4rem 2rem'}}>
+        <Heading as="h1">{title}</Heading>
+        <p style={{color: 'var(--ifm-color-secondary-darkest)', marginBottom: '2rem'}}>
+          {isEn
+            ? 'We offer professional enterprise-grade software outsourcing services backed by years of .NET ecosystem development experience. No matter the size of your project, we deliver high-quality, reliable solutions.'
+            : '我们提供专业的企业级软件外包服务，基于多年 .NET 生态开发经验，无论项目大小，我们都能为您交付高质量、可靠的解决方案。'}
+        </p>
+
+        <div style={{display: 'flex', flexDirection: 'column', gap: '2rem'}}>
+
+          {/* ── 关于我们 ── */}
+          <div style={{
+            border: '1px solid var(--ifm-color-emphasis-300)',
+            borderRadius: '8px',
+            padding: '1.5rem',
+          }}>
+            <Heading as="h2">
+              {isEn ? 'Who We Are' : '关于我们'}
+            </Heading>
+            <p style={{margin: 0, color: 'var(--ifm-color-secondary-darkest)'}}>
+              {isEn
+                ? 'Our core team has deep expertise in the .NET technology stack, with extensive experience in WPF, Avalonia, MAUI, and other desktop/mobile frameworks. We provide end-to-end services from requirements analysis and architecture design to development and delivery. We have delivered production-grade auto-update solutions and enterprise applications for companies across multiple industries.'
+                : '核心团队长期深耕 .NET 技术栈，在 WPF、Avalonia、MAUI 等桌面/移动框架方面有深厚积累。我们提供从需求分析、架构设计到开发交付的全流程服务，已为多家跨行业企业交付生产级自动更新解决方案与企业级应用。'}
+            </p>
+          </div>
+
+          {/* ── 服务范围 ── */}
+          <div style={{
+            border: '1px solid var(--ifm-color-emphasis-300)',
+            borderRadius: '8px',
+            padding: '1.5rem',
+          }}>
+            <Heading as="h2">
+              {isEn ? 'Our Services' : '服务范围'}
+            </Heading>
+            <p style={{margin: 0, color: 'var(--ifm-color-secondary-darkest)'}}>
+              {isEn
+                ? 'Including but not limited to: enterprise desktop application development (WPF / Avalonia / MAUI), auto-update system integration and customization, third-party system integration, legacy system migration and modernization, performance optimization, and technical consulting.'
+                : '包括但不限于：企业级桌面应用开发（WPF / Avalonia / MAUI）、自动更新系统集成与定制、第三方系统对接、遗留系统迁移与现代化改造、性能优化与技术咨询。'}
+            </p>
+          </div>
+
+          {/* ── 合作方式 ── */}
+          <div style={{
+            border: '1px solid var(--ifm-color-emphasis-300)',
+            borderRadius: '8px',
+            padding: '1.5rem',
+          }}>
+            <Heading as="h2">
+              {isEn ? 'How to Engage' : '合作方式'}
+            </Heading>
+            <p style={{color: 'var(--ifm-color-secondary-darkest)', marginBottom: '1rem'}}>
+              {isEn
+                ? 'Scan the QR code below to contact us with your project requirements. We will get back to you within 1–2 business days to discuss your needs and propose a tailored solution.'
+                : '扫描下方二维码联系我们，附上项目需求说明。我们会在 1–2 个工作日内与您取得联系，讨论您的需求并提供定制化方案。'}
+            </p>
+            <div style={{textAlign: 'center'}}>
+              <img src={contactImg} alt={isEn ? 'Contact QR Code' : '联系方式二维码'} style={{maxWidth: '100%', borderRadius: '8px'}} />
+            </div>
+          </div>
+
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/website/src/pages/paid-consulting.js
+++ b/website/src/pages/paid-consulting.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Heading from '@theme/Heading';
+import contactImg from '@site/docs/doc/imgs/contact.png';
+
+export default function PaidConsulting() {
+  const {i18n} = useDocusaurusContext();
+  const isEn = i18n.currentLocale === 'en';
+
+  const title = isEn ? 'Paid Consultation' : '付费咨询';
+  const description = isEn
+    ? 'One-on-one technical support and consulting services for GeneralUpdate and .NET'
+    : '针对 GeneralUpdate 与 .NET 技术的一对一技术支持与咨询服务';
+
+  return (
+    <Layout title={title} description={description}>
+      <main style={{maxWidth: 800, margin: '0 auto', padding: '4rem 2rem'}}>
+        <Heading as="h1">{title}</Heading>
+        <p style={{color: 'var(--ifm-color-secondary-darkest)', marginBottom: '2rem'}}>
+          {isEn
+            ? 'We offer one-on-one paid consultation services to help you get the most out of GeneralUpdate and solve complex .NET technical challenges. Due to the large number of individual inquiries, paid consultation ensures you receive dedicated, timely support.'
+            : '我们提供一对一付费咨询服务，帮助您充分发挥 GeneralUpdate 的价值，解决复杂的 .NET 技术难题。由于个人咨询量较大，付费咨询确保您获得专注、及时的技术支持。'}
+        </p>
+
+        <div style={{display: 'flex', flexDirection: 'column', gap: '2rem'}}>
+
+          {/* ── GeneralUpdate 组件使用咨询 ── */}
+          <div style={{
+            border: '1px solid var(--ifm-color-emphasis-300)',
+            borderRadius: '8px',
+            padding: '1.5rem',
+          }}>
+            <Heading as="h2">
+              {isEn ? 'GeneralUpdate Consulting' : 'GeneralUpdate 组件使用咨询'}
+            </Heading>
+            <p style={{margin: 0, color: 'var(--ifm-color-secondary-darkest)'}}>
+              {isEn
+                ? 'From basic integration to advanced customization — get expert guidance on integrating GeneralUpdate into your applications. We cover configuration, differential updates, pipeline design, driver adaptation, security hardening, and best practices for production deployment.'
+                : '从基础集成到高级定制——获取将 GeneralUpdate 集成到您应用中的专家指导。涵盖配置调优、差量更新、管线设计、驱动适配、安全加固以及生产环境部署的最佳实践。'}
+            </p>
+          </div>
+
+          {/* ── .NET 技术咨询 ── */}
+          <div style={{
+            border: '1px solid var(--ifm-color-emphasis-300)',
+            borderRadius: '8px',
+            padding: '1.5rem',
+          }}>
+            <Heading as="h2">
+              {isEn ? '.NET Technical Consulting' : '.NET 技术咨询'}
+            </Heading>
+            <p style={{margin: 0, color: 'var(--ifm-color-secondary-darkest)'}}>
+              {isEn
+                ? 'Deep expertise across the .NET ecosystem — WPF, Avalonia, MAUI, ASP.NET Core, and more. Whether you need architecture review, performance optimization, migration planning, or troubleshooting, our team is ready to help.'
+                : '深厚的 .NET 生态技术积累——WPF、Avalonia、MAUI、ASP.NET Core 等。无论您需要架构评审、性能优化、迁移规划还是疑难排错，我们的团队随时为您提供支持。'}
+            </p>
+          </div>
+
+          {/* ── 方案咨询 ── */}
+          <div style={{
+            border: '1px solid var(--ifm-color-emphasis-300)',
+            borderRadius: '8px',
+            padding: '1.5rem',
+          }}>
+            <Heading as="h2">
+              {isEn ? 'Solution Consulting' : '方案咨询'}
+            </Heading>
+            <p style={{margin: 0, color: 'var(--ifm-color-secondary-darkest)'}}>
+              {isEn
+                ? 'Need a tailored solution for your project? We provide solution design and consulting services covering auto-update architecture, CI/CD integration with automated packaging, cross-platform update strategies, and general .NET application architecture. Tell us your requirements and we\'ll design a solution that fits.'
+                : '需要为您的项目量身定制方案？我们提供方案设计与咨询服务，涵盖自动更新架构规划、CI/CD 自动打包集成、跨平台更新策略以及通用 .NET 应用架构设计。告诉我们您的需求，我们将为您设计合适的方案。'}
+            </p>
+          </div>
+
+          {/* ── 联系方式 ── */}
+          <div style={{
+            border: '1px solid var(--ifm-color-emphasis-300)',
+            borderRadius: '8px',
+            padding: '1.5rem',
+            background: 'var(--ifm-color-warning-contrast-background)',
+          }}>
+            <Heading as="h2">
+              {isEn ? 'Get in Touch' : '联系方式'}
+            </Heading>
+            <p style={{color: 'var(--ifm-color-secondary-darkest)', marginBottom: '1rem'}}>
+              {isEn
+                ? 'Scan the QR code below to contact us. Please state your purpose when adding (WeChat recommended).'
+                : '扫描下方二维码联系我们，加好友请注明来意（推荐微信）。'}
+            </p>
+            <div style={{textAlign: 'center'}}>
+              <img src={contactImg} alt={isEn ? 'Contact QR Code' : '联系方式二维码'} style={{maxWidth: '100%', borderRadius: '8px'}} />
+            </div>
+          </div>
+
+        </div>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary

Add four new pages and update the contact page for the GeneralUpdate documentation website.

### New Pages
- **/corporate-wall** — 企业墙：4 companies using GeneralUpdate in production (天津云度科技, 上海铱泓科技, 天津\*\*\*\*化工工程有限公司, 沈阳\*\*汽车科技有限公司)
- **/oss-partners** — 开源生态伙伴：7 open-source ecosystem partners (Semi.Avalonia, Ursa.Avalonia, WPFDevelopers, Layui-WPF, AntdUI, routin.ai, OpenCowork)
- **/outsourcing** — 软件外包服务：Software outsourcing services page
- **/paid-consulting** — 付费咨询：Paid consulting for GeneralUpdate & .NET

### Contact Page Updates
- Removed GitHub Issues and Sponsorship sections
- Removed Email card, replaced with QR code scan contact card
- Moved Paid Consultation to its own dedicated page

### Navbar Changes
- 定价 dropdown: added 软件外包服务 and 付费咨询 sub-items
- Right navbar: added 企业墙 and 开源生态伙伴 links
- All items have zh-Hans and en i18n translations

### Design
- Card layout with rounded corners (12px) + hover translate/shadow effects
- Dark mode support via Infima CSS variables
- Consistent with existing cosmic theme design language

🤖 Generated with [Claude Code](https://claude.com/claude-code)