### PR TITLE
fix: remove unused ToVersion from sample server and client code

### DIFF
--- a/src/Hub/Samples/OssSample.cs
+++ b/src/Hub/Samples/OssSample.cs
@@ -70,7 +70,7 @@ public class OssSample : ISample
                     foreach (var v in e.Info.Body)
                     {
                         var type = v.IsCrossVersion == true
-                            ? $"[差分 {v.FromVersion}→{v.ToVersion}]"
+                            ? $"[差分 {v.FromVersion} → {v.Version}]"
                             : "[完整包]";
                         Console.WriteLine($"    v{v.Version}  {type}");
                         Console.WriteLine($"      Name: {v.Name}");

--- a/src/Server/DTOs/VerificationResultDTO.cs
+++ b/src/Server/DTOs/VerificationResultDTO.cs
@@ -86,9 +86,4 @@ public record VerificationResultDTO
     /// 跨版本升级的源版本号
     /// </summary>
     public string? FromVersion { get; set; }
-
-    /// <summary>
-    /// 跨版本升级的目标版本号
-    /// </summary>
-    public string? ToVersion { get; set; }
 }

--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -91,14 +91,14 @@ var handleVerification = (VerifyDTO request) =>
             Format = v.Format ?? ".zip", Size = v.Size, IsFreeze = v.IsFreeze,
             UpgradeMode = requestUpgradeMode,
             IsCrossVersion = v.IsCrossVersion ?? false,
-            FromVersion = v.FromVersion, ToVersion = v.ToVersion
+            FromVersion = v.FromVersion
         });
     }
 
     var modeLabel = requestUpgradeMode == 2 ? "CrossVersion" : "VersionChain";
     Console.WriteLine($"[Verification] Returning {results.Count} packages (Mode: {modeLabel})");
     foreach (var r in results)
-        Console.WriteLine($"    {r.Version} — {r.Name} ({(r.IsCrossVersion == true ? $"Cross {r.FromVersion}→{r.ToVersion}" : "Full")})");
+        Console.WriteLine($"    {r.Version} — {r.Name} ({(r.IsCrossVersion == true ? $"Cross {r.FromVersion} → {r.Version}" : "Full")})");
 
     return Results.Ok(HttpResponseDTO<IEnumerable<VerificationResultDTO>>.Success(results,
         $"Found {results.Count} update(s)."));
@@ -169,7 +169,7 @@ Console.WriteLine("╚═══════════════════�
 if (versionStore.Count > 0)
 {
     foreach (var v in versionStore.OrderBy(v => new Version(v.Version!)))
-        Console.WriteLine($"  {v.Version,-12} AppType={v.AppType} {(v.IsCrossVersion == true ? $"Cross {v.FromVersion}→{v.ToVersion}" : "Full")}  {v.PacketName}");
+        Console.WriteLine($"  {v.Version,-12} AppType={v.AppType} {(v.IsCrossVersion == true ? $"Cross {v.FromVersion} → {v.Version}" : "Full")}  {v.PacketName}");
 }
 else
 {
@@ -240,5 +240,4 @@ record VersionEntry
     public bool? IsFreeze { get; set; }
     public bool? IsCrossVersion { get; set; }
     public string? FromVersion { get; set; }
-    public string? ToVersion { get; set; }
 }


### PR DESCRIPTION
Closes #112

## Summary

Aligns the sample server and client code with the upstream SDK/API changes: `ToVersion` was removed from the client SDK's `VersionEntry` and server API's `VerificationResultDTO` because it was never consumed. The target version is already represented by the `Version` field itself, so `ToVersion` was redundant.

### Changes
- Removed `ToVersion` from `VerificationResultDTO` (DTOs)
- Removed `ToVersion` from `VersionEntry` (Program.cs internal model)
- Updated cross-version log output to show `{FromVersion} → {Version}` for clarity
- Updated OSS sample output to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)