### PR TITLE
feat(website): update enterprise/OSS walls content & tile-style layout

### DIFF
--- a/website/src/pages/corporate-wall.js
+++ b/website/src/pages/corporate-wall.js
@@ -26,8 +26,8 @@ export default function CorporateWall() {
   const companies = [
     {
       name: '天津云度科技',
-      description: '专注于云计算与数字化转型，在多条产品线中集成 GeneralUpdate 实现客户端自动更新。',
-      descriptionEn: 'Focused on cloud computing and digital transformation, integrating GeneralUpdate across multiple product lines for automatic client updates.',
+      description: '专注于智慧城市应用技术与产品服务，在大数据、AI 技术服务、平台运营及系统集成等领域为政府及企业提供一站式信息化解决方案。',
+      descriptionEn: 'Focused on smart city application technology and products, providing one-stop digital solutions for governments and enterprises in big data, AI services, platform operations, and system integration.',
     },
     {
       name: '上海铱泓科技',
@@ -43,6 +43,16 @@ export default function CorporateWall() {
       name: '沈阳**汽车科技有限公司',
       description: '在车载智能终端软件更新中采用 GeneralUpdate 解决方案。',
       descriptionEn: 'Adopting GeneralUpdate solutions for software updates in automotive intelligent terminals.',
+    },
+    {
+      name: '杭州猿通信息科技有限责任公司',
+      description: '专注于 AI 原生应用与数据处理技术研发，旗下核心产品"决策链（DecisionLinnc）"定位为下一代智能体操作系统，致力于为金融、医疗、科研等领域提供智能化解决方案。',
+      descriptionEn: 'Specializing in AI-native application and data processing technologies, with the core product "DecisionLinnc" positioned as the next-generation agent operating system, providing intelligent solutions for finance, healthcare, and scientific research.',
+    },
+    {
+      name: '上海**导航技术股份有限公司',
+      description: '将 GeneralUpdate 应用于高精度卫星导航定位系统的客户端软件升级与远程运维管理。',
+      descriptionEn: 'Applying GeneralUpdate for client software update and remote operations management in high-precision satellite navigation and positioning systems.',
     },
   ];
 

--- a/website/src/pages/corporate-wall.module.css
+++ b/website/src/pages/corporate-wall.module.css
@@ -1,10 +1,10 @@
 /* ════════════════════════════════════════════════════════════════
-   CORPORATE WALL — Card Grid Layout
+   CORPORATE WALL — Tile Grid Layout
    ════════════════════════════════════════════════════════════════ */
 
 /* ── Page layout ── */
 .page {
-  max-width: 1000px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 4rem 2rem;
 }
@@ -27,36 +27,38 @@
   font-size: 1.1rem;
 }
 
-/* ── Card grid ── */
+/* ── Tile grid: auto-fit, horizontally wrapping ── */
 .cardGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
 }
 
-/* ── Individual card ── */
+/* ── Individual tile ── */
 .card {
   background: var(--ifm-card-background-color, #fff);
-  border: 3px solid var(--ifm-color-emphasis-300);
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.08);
-  transition: all 0.3s ease;
+  border: 2px solid var(--ifm-color-emphasis-300);
+  border-radius: 16px;
+  padding: 1.25rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  transition: all 0.25s ease;
+  display: flex;
+  flex-direction: column;
 }
 
 .card:hover {
-  transform: translate(-4px, -4px);
-  box-shadow: 10px 10px 0 rgba(0, 0, 0, 0.12);
+  transform: translateY(-6px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
   border-color: var(--ifm-color-primary);
 }
 
-/* ── Card header: company name top-left ── */
+/* ── Card header: company name ── */
 .cardHeader {
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.6rem;
 }
 
 .cardName {
-  font-size: 1.3rem;
+  font-size: 1.1rem;
   font-weight: 800;
   margin: 0;
   color: var(--ifm-color-primary-darkest);
@@ -65,10 +67,11 @@
 
 /* ── Description ── */
 .cardDesc {
-  font-size: 0.95rem;
-  line-height: 1.6;
+  font-size: 0.88rem;
+  line-height: 1.55;
   color: var(--ifm-color-emphasis-700);
   margin: 0;
+  flex: 1;
 }
 
 /* ════════════════════════════════════════════════════════════════
@@ -77,11 +80,11 @@
 [data-theme='dark'] .card {
   background: var(--ifm-background-surface-color);
   border-color: rgba(93, 173, 226, 0.25);
-  box-shadow: 6px 6px 0 rgba(93, 173, 226, 0.1);
+  box-shadow: 0 4px 12px rgba(93, 173, 226, 0.08);
 }
 
 [data-theme='dark'] .card:hover {
-  box-shadow: 10px 10px 0 rgba(93, 173, 226, 0.2);
+  box-shadow: 0 8px 24px rgba(93, 173, 226, 0.18);
   border-color: var(--ifm-color-primary);
 }
 

--- a/website/src/pages/oss-partners.js
+++ b/website/src/pages/oss-partners.js
@@ -69,6 +69,24 @@ export default function OssPartners() {
       description: '开源协同办公平台，提供团队协作、文档管理、项目管理等企业级协同功能。',
       descriptionEn: 'An open-source collaborative office platform providing enterprise-grade collaboration features including team workspace, document management, and project management.',
     },
+    {
+      name: 'Gradio.Net',
+      url: 'https://github.com/feiyun0112/Gradio.Net',
+      description: 'Gradio 的 .NET 移植版，无需前端代码即可为机器学习模型、API 或任意函数快速构建演示或 Web 应用。',
+      descriptionEn: 'A .NET port of Gradio, allowing you to quickly build demos or web applications for ML models, APIs, or any functions without frontend code.',
+    },
+    {
+      name: '3C-demo',
+      url: 'https://github.com/LessIsMoreInSZ/3C-demo',
+      description: '抵制无良培训班，开源 3C 电商 Demo 项目，助力初学者学习真实项目开发。',
+      descriptionEn: 'Open-source 3C e-commerce demo project, helping beginners learn real-world project development.',
+    },
+    {
+      name: 'HagiCode',
+      url: 'https://hagicode.com/',
+      description: '全球不唯一，但是超级好用的 Agentic Coding 软件，集 AI 编程、游戏化工作空间于一体的全栈开发平台。',
+      descriptionEn: 'Not the only one in the world, but a super useful Agentic Coding software — an all-in-one AI-powered development workspace with gamification.',
+    },
   ];
 
   const title = isEn ? 'Open Source Partners' : '开源生态伙伴';

--- a/website/src/pages/oss-partners.module.css
+++ b/website/src/pages/oss-partners.module.css
@@ -1,10 +1,10 @@
 /* ════════════════════════════════════════════════════════════════
-   OSS PARTNERS — Card Grid Layout
+   OSS PARTNERS — Tile Grid Layout
    ════════════════════════════════════════════════════════════════ */
 
 /* ── Page layout ── */
 .page {
-  max-width: 1000px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 4rem 2rem;
 }
@@ -27,26 +27,28 @@
   font-size: 1.1rem;
 }
 
-/* ── Card grid ── */
+/* ── Tile grid: auto-fit, horizontally wrapping ── */
 .cardGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
 }
 
-/* ── Individual card ── */
+/* ── Individual tile ── */
 .card {
   background: var(--ifm-card-background-color, #fff);
-  border: 3px solid var(--ifm-color-emphasis-300);
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.08);
-  transition: all 0.3s ease;
+  border: 2px solid var(--ifm-color-emphasis-300);
+  border-radius: 16px;
+  padding: 1.25rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  transition: all 0.25s ease;
+  display: flex;
+  flex-direction: column;
 }
 
 .card:hover {
-  transform: translate(-4px, -4px);
-  box-shadow: 10px 10px 0 rgba(0, 0, 0, 0.12);
+  transform: translateY(-6px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
   border-color: var(--ifm-color-primary);
 }
 
@@ -54,12 +56,12 @@
 .cardHeader {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  margin-bottom: 0.75rem;
+  gap: 0.2rem;
+  margin-bottom: 0.6rem;
 }
 
 .cardName {
-  font-size: 1.5rem;
+  font-size: 1.1rem;
   font-weight: 800;
   margin: 0;
   color: var(--ifm-color-primary-darkest);
@@ -67,7 +69,7 @@
 }
 
 .cardLink {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   color: var(--ifm-color-primary);
   word-break: break-all;
   display: inline-block;
@@ -79,10 +81,11 @@
 
 /* ── Description ── */
 .cardDesc {
-  font-size: 0.95rem;
-  line-height: 1.6;
+  font-size: 0.88rem;
+  line-height: 1.55;
   color: var(--ifm-color-emphasis-700);
   margin: 0;
+  flex: 1;
 }
 
 /* ════════════════════════════════════════════════════════════════
@@ -91,11 +94,11 @@
 [data-theme='dark'] .card {
   background: var(--ifm-background-surface-color);
   border-color: rgba(93, 173, 226, 0.25);
-  box-shadow: 6px 6px 0 rgba(93, 173, 226, 0.1);
+  box-shadow: 0 4px 12px rgba(93, 173, 226, 0.08);
 }
 
 [data-theme='dark'] .card:hover {
-  box-shadow: 10px 10px 0 rgba(93, 173, 226, 0.2);
+  box-shadow: 0 8px 24px rgba(93, 173, 226, 0.18);
   border-color: var(--ifm-color-primary);
 }
 


### PR DESCRIPTION
## 变更内容

### 1️⃣ 企业墙 — 新增企业 + 修正描述
- 新增 **杭州猿通信息科技有限责任公司**（AI 原生应用与数据处���）
- 新增 **上海\*\*导航技术股份有限公司**（高精度卫星导航定位系统）
- 修正 **天津云度科技** 描述为智慧城市应用技术与产品服务

### 2️⃣ 企业墙 & 开源生态伙伴墙 — 磁贴样式布局
两张墙的卡片样式改为统一磁贴（tile）布局：`repeat(auto-fit, minmax(300px, 1fr))`，自动适应横向排列，hover 效果改为上浮

### 3️⃣ 开源生态墙 — 新增 3 个条目
| 项目 | 链接 |
|------|------|
| **Gradio.Net** | https://github.com/feiyun0112/Gradio.Net |
| **3C-demo** | https://github.com/LessIsMoreInSZ/3C-demo |
| **HagiCode** | https://hagicode.com/ |

Closes # (关联 issue)