### PR TITLE
fix: remove tmp skill codegen embedded repo from Samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ bld/
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
 
+# Ignore temporary skill codegen embedded repo
+tmpgeneralupdate-skill-codegen/
+
 #NUNIT
 *.VisualState.xml
 TestResult.xml


### PR DESCRIPTION
## 背景

 是一个误放的临时目录 —— 它是 [GeneralLibrary/generalupdate-skill-codegen](https://github.com/GeneralLibrary/generalupdate-skill-codegen) 的 git clone，嵌套在 Samples 仓库中，从未被提交过（untracked）。

专门的 skill 仓库已经存在于 `github.com/GeneralLibrary/generalupdate-skill-codegen`。

## 变更内容

- 删除了 `src/Hub/Samples/tmpgeneralupdate-skill-codegen/` 目录
- 添加了 `tmpgeneralupdate-skill-codegen/` 到 `.gitignore`，防止复发

## 验证

- `git status` 确认无残留 untracked 文件
- `.gitignore` 更新生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)