### PR TITLE
feat(docs): nest Core-flow under GeneralUpdate.Core as collapsible category

### DIFF
--- a/website/docs/doc/Core-flow.md
+++ b/website/docs/doc/Core-flow.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+sidebar_label: 执行流程详解
 ---
 
 # GeneralUpdate.Core — 执行流程详解

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/doc/Core-flow.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/doc/Core-flow.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+sidebar_label: Execution Flow
 ---
 
 # GeneralUpdate.Core — Execution Flow Deep Dive

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -34,8 +34,14 @@ const sidebars = {
       collapsed: false,
       items: [
         'doc/Component Introduction',
-        'doc/GeneralUpdate.Core',
-        'doc/Core-flow',
+        {
+          type: 'category',
+          label: 'GeneralUpdate.Core',
+          collapsible: true,
+          collapsed: true,
+          link: { type: 'doc', id: 'doc/GeneralUpdate.Core' },
+          items: ['doc/Core-flow'],
+        },
         'doc/GeneralUpdate.Bowl',
         'doc/GeneralUpdate.Differential',
         'doc/GeneralUpdate.Drivelution',


### PR DESCRIPTION
## Summary

After the Core-flow page was added (PR #133), it showed as a separate top-level entry in the Components sidebar. This PR nests it inside a collapsible **GeneralUpdate.Core** category instead.

### Changes
| File | Change |
|------|--------|
| `website/sidebars.js` | Wrap Core as `category`, nest Core-flow as child item |
| `website/docs/doc/Core-flow.md` | Added `sidebar_label: 执行流程详解` |
| `website/i18n/en/.../Core-flow.md` | Added `sidebar_label: Execution Flow` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)