### PR TITLE
feat(docs): add click-to-zoom modal with panzoom for mermaid flowcharts

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,6 +12,7 @@
         "@docusaurus/preset-classic": "3.1.1",
         "@docusaurus/theme-mermaid": "^3.1.1",
         "@mdx-js/react": "^3.0.0",
+        "@panzoom/panzoom": "^4.6.2",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.0.0",
@@ -2957,6 +2958,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@panzoom/panzoom": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@panzoom/panzoom/-/panzoom-4.6.2.tgz",
+      "integrity": "sha512-Zn3B5/hwa6eYIPRSKX0xf2clv8nviTX8AnAU5kU/EugiTDhG41ya2wlBqYrZJYCWQROr/5XkWObZhIkepi89qw==",
+      "license": "MIT"
     },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",

--- a/website/package.json
+++ b/website/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/preset-classic": "3.1.1",
     "@docusaurus/theme-mermaid": "^3.1.1",
     "@mdx-js/react": "^3.0.0",
+    "@panzoom/panzoom": "^4.6.2",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -637,60 +637,6 @@
 }
 
 /* ════════════════════════════════════════════════════════════════
-   MERMAID DIAGRAMS — horizontal scroll + zoom on hover
-   ════════════════════════════════════════════════════════════════ */
-
-/* Wrapper around each mermaid SVG: enable horizontal scroll */
-.docusaurus-mermaid-container {
-  overflow-x: auto;
-  overflow-y: hidden;
-  -webkit-overflow-scrolling: touch;
-  margin: 1.5rem 0;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: var(--gu-radius);
-  background: #fff;
-  padding: 0.5rem;
-}
-
-[data-theme='dark'] .docusaurus-mermaid-container {
-  background: #1a1a2e;
-  border-color: rgba(93, 173, 226, 0.15);
-}
-
-/* Allow the SVG to keep its natural width (don't shrink to container) */
-.docusaurus-mermaid-container svg {
-  width: auto !important;
-  max-width: none !important;
-  height: auto !important;
-  min-width: 600px; /* Ensures diagrams don't get squashed too small */
-  display: block;
-}
-
-/* Zoom-on-hover: scale up slightly for readability */
-.docusaurus-mermaid-container:hover {
-  box-shadow: 0 2px 12px rgba(0,0,0,0.12);
-}
-[data-theme='dark'] .docusaurus-mermaid-container:hover {
-  box-shadow: 0 2px 12px rgba(0,0,0,0.35);
-}
-
-/* Make the scrollbar visible and styled */
-.docusaurus-mermaid-container::-webkit-scrollbar {
-  height: 8px;
-}
-.docusaurus-mermaid-container::-webkit-scrollbar-track {
-  background: var(--ifm-color-emphasis-100);
-  border-radius: 4px;
-}
-.docusaurus-mermaid-container::-webkit-scrollbar-thumb {
-  background: var(--ifm-color-emphasis-400);
-  border-radius: 4px;
-}
-.docusaurus-mermaid-container::-webkit-scrollbar-thumb:hover {
-  background: var(--ifm-color-emphasis-500);
-}
-
-/* ════════════════════════════════════════════════════════════════
    PRINT-FRIENDLY
    ════════════════════════════════════════════════════════════════ */
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -637,6 +637,60 @@
 }
 
 /* ════════════════════════════════════════════════════════════════
+   MERMAID DIAGRAMS — horizontal scroll + zoom on hover
+   ════════════════════════════════════════════════════════════════ */
+
+/* Wrapper around each mermaid SVG: enable horizontal scroll */
+.docusaurus-mermaid-container {
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  margin: 1.5rem 0;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--gu-radius);
+  background: #fff;
+  padding: 0.5rem;
+}
+
+[data-theme='dark'] .docusaurus-mermaid-container {
+  background: #1a1a2e;
+  border-color: rgba(93, 173, 226, 0.15);
+}
+
+/* Allow the SVG to keep its natural width (don't shrink to container) */
+.docusaurus-mermaid-container svg {
+  width: auto !important;
+  max-width: none !important;
+  height: auto !important;
+  min-width: 600px; /* Ensures diagrams don't get squashed too small */
+  display: block;
+}
+
+/* Zoom-on-hover: scale up slightly for readability */
+.docusaurus-mermaid-container:hover {
+  box-shadow: 0 2px 12px rgba(0,0,0,0.12);
+}
+[data-theme='dark'] .docusaurus-mermaid-container:hover {
+  box-shadow: 0 2px 12px rgba(0,0,0,0.35);
+}
+
+/* Make the scrollbar visible and styled */
+.docusaurus-mermaid-container::-webkit-scrollbar {
+  height: 8px;
+}
+.docusaurus-mermaid-container::-webkit-scrollbar-track {
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 4px;
+}
+.docusaurus-mermaid-container::-webkit-scrollbar-thumb {
+  background: var(--ifm-color-emphasis-400);
+  border-radius: 4px;
+}
+.docusaurus-mermaid-container::-webkit-scrollbar-thumb:hover {
+  background: var(--ifm-color-emphasis-500);
+}
+
+/* ════════════════════════════════════════════════════════════════
    PRINT-FRIENDLY
    ════════════════════════════════════════════════════════════════ */
 

--- a/website/src/theme/Mermaid/index.js
+++ b/website/src/theme/Mermaid/index.js
@@ -1,0 +1,182 @@
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import ErrorBoundary from '@docusaurus/ErrorBoundary';
+import { ErrorBoundaryErrorMessageFallback } from '@docusaurus/theme-common';
+import {
+  MermaidContainerClassName,
+  useMermaidRenderResult,
+} from '@docusaurus/theme-mermaid/client';
+import panzoom from '@panzoom/panzoom';
+
+import styles from './styles.module.css';
+
+function MermaidRenderResult({ renderResult }) {
+  const ref = useRef(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const modalRef = useRef(null);
+  const zoomRef = useRef(null);
+  const instanceRef = useRef(null);
+
+  useEffect(() => {
+    const div = ref.current;
+    renderResult.bindFunctions?.(div);
+  }, [renderResult]);
+
+  // Handle click on the mermaid diagram to open modal
+  const handleClick = useCallback(() => {
+    setModalOpen(true);
+  }, []);
+
+  // Initialize panzoom when modal opens
+  useEffect(() => {
+    if (!modalOpen || !modalRef.current) return;
+
+    const modalEl = modalRef.current;
+    const svgEl = modalEl.querySelector('svg');
+    if (!svgEl) return;
+
+    // Clean up any previous instance
+    if (instanceRef.current) {
+      instanceRef.current.destroy();
+    }
+
+    const instance = panzoom(svgEl, {
+      maxScale: 10,
+      minScale: 0.3,
+      step: 0.3,
+      contain: 'outside',
+      pinchAndPan: true,
+    });
+    instanceRef.current = instance;
+
+    // Reset zoom on open
+    // Use a small delay to let the modal render finish
+    const resetTimer = setTimeout(() => {
+      instance.reset({ animate: false });
+    }, 50);
+
+    // Keyboard handlers
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        setModalOpen(false);
+      }
+      // Zoom with +/-
+      if (e.key === '+' || e.key === '=') {
+        e.preventDefault();
+        instance.zoomIn();
+      }
+      if (e.key === '-') {
+        e.preventDefault();
+        instance.zoomOut();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      clearTimeout(resetTimer);
+      window.removeEventListener('keydown', handleKeyDown);
+      if (instanceRef.current) {
+        instanceRef.current.destroy();
+        instanceRef.current = null;
+      }
+    };
+  }, [modalOpen]);
+
+  return (
+    <>
+      <div
+        ref={ref}
+        className={`${MermaidContainerClassName} ${styles.container}`}
+        dangerouslySetInnerHTML={{ __html: renderResult.svg }}
+        onClick={handleClick}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => { if (e.key === 'Enter') handleClick(); }}
+        title="Click to zoom"
+      />
+
+      {modalOpen && (
+        <div
+          className={styles.overlay}
+          onClick={() => setModalOpen(false)}
+          role="presentation"
+        >
+          <div className={styles.toolbar}>
+            <button
+              className={styles.toolBtn}
+              onClick={(e) => {
+                e.stopPropagation();
+                instanceRef.current?.zoomIn();
+              }}
+              title="Zoom in (+)"
+            >
+              ＋
+            </button>
+            <button
+              className={styles.toolBtn}
+              onClick={(e) => {
+                e.stopPropagation();
+                instanceRef.current?.zoomOut();
+              }}
+              title="Zoom out (-)"
+            >
+              −
+            </button>
+            <button
+              className={styles.toolBtn}
+              onClick={(e) => {
+                e.stopPropagation();
+                instanceRef.current?.reset({ animate: true });
+              }}
+              title="Reset"
+            >
+              ↺
+            </button>
+            <button
+              className={styles.toolBtn}
+              onClick={(e) => {
+                e.stopPropagation();
+                setModalOpen(false);
+              }}
+              title="Close (Esc)"
+            >
+              ✕
+            </button>
+            <span className={styles.toolHint}>
+              Scroll to zoom · Drag to pan
+            </span>
+          </div>
+          <div
+            className={styles.modalBody}
+            onClick={(e) => e.stopPropagation()}
+            role="presentation"
+          >
+            <div
+              ref={modalRef}
+              className={styles.zoomContainer}
+              dangerouslySetInnerHTML={{ __html: renderResult.svg }}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function MermaidRenderer({ value }) {
+  const renderResult = useMermaidRenderResult({ text: value });
+  if (renderResult === null) {
+    return null;
+  }
+  return <MermaidRenderResult renderResult={renderResult} />;
+}
+
+export default function Mermaid(props) {
+  return (
+    <ErrorBoundary
+      fallback={(params) => <ErrorBoundaryErrorMessageFallback {...params} />}
+    >
+      <MermaidRenderer {...props} />
+    </ErrorBoundary>
+  );
+}

--- a/website/src/theme/Mermaid/styles.module.css
+++ b/website/src/theme/Mermaid/styles.module.css
@@ -1,0 +1,116 @@
+/* ── Inline diagram (clickable) ─────────────────────────── */
+.container {
+  max-width: 100%;
+  cursor: zoom-in;
+  transition: box-shadow 0.2s ease;
+}
+
+.container > svg {
+  max-width: 100%;
+}
+
+.container:hover {
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+}
+
+[data-theme='dark'] .container:hover {
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
+}
+
+/* ── Fullscreen modal overlay ─────────────────────────── */
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(4px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  animation: overlayIn 0.2s ease;
+}
+
+@keyframes overlayIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* ── Toolbar at top of overlay ─────────────────────────── */
+.toolbar {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(6px);
+  border-radius: 8px;
+  padding: 6px 10px;
+  z-index: 10000;
+  user-select: none;
+}
+
+.toolBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: #eee;
+  font-size: 16px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.toolBtn:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.toolBtn:active {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.toolHint {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 12px;
+  margin-left: 6px;
+  padding-left: 8px;
+  border-left: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+/* ── Scrollable body area (for large diagrams) ─────────── */
+.modalBody {
+  width: 90vw;
+  height: 85vh;
+  overflow: auto;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.4);
+  cursor: grab;
+}
+
+.modalBody:active {
+  cursor: grabbing;
+}
+
+[data-theme='dark'] .modalBody {
+  background: #1a1a2e;
+}
+
+/* ── Panzoom container inside modal body ───────────────── */
+.zoomContainer {
+  display: inline-block;
+  padding: 32px;
+  transform-origin: 0 0;
+  touch-action: none;
+}
+
+.zoomContainer svg {
+  display: block;
+  max-width: none;
+}


### PR DESCRIPTION
## Summary

之前 PR #135 的外置滚动条方案体验不够好，用户需求是「可以放大查看」。改用 **Panzoom 交互式放大查看器**。

### 实现方案
通过 **Docusaurus theme shadowing** 自定义 @theme/Mermaid 组件：

| 文件 | 作用 |
|------|------|
| src/theme/Mermaid/index.js | 完全替换 Mermaid 渲染组件，添加点击弹窗 + Panzoom 交互 |
| src/theme/Mermaid/styles.module.css | 弹窗、工具栏、缩放容器样式 (CSS Modules) |
| src/css/custom.css | 移除旧的外置滚动条 CSS |
| package.json | 新增依赖 @panzoom/panzoom |

### 交互体验
- 点击流程图 - 弹出全屏遮罩层
- 鼠标滚轮 - 放大/缩小
- 拖拽 - 平移视图
- 工具栏按钮：放大/缩小/重置/关闭
- 键盘快捷键：Esc 关闭，+/= 放大，- 缩小
- 深色/浅色主题适配
- 遮罩背景模糊 + 平滑动画